### PR TITLE
Fix `PlanarSet` typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -289,7 +289,7 @@ declare namespace Flatten {
         index: IntervalTree;
 
         // public methods
-        add(element: IndexableElement): PlanarSet;
+        add(element: IndexableElement): this;
         delete(element: IndexableElement): boolean;
         clear() : void;
         hit(pt: Point): IndexableElement[];


### PR DESCRIPTION
The `add` method was giving a return type of `PlanarSet`, which is
incompatible with `Set#add`. In such cases, the return value should be
specified as `this`.

I have not reviewed the new typings file in detail, but it seems to
work OK at least as regards the parts of the library that I use in my
app.