### PR TITLE
fix(commonjs): Use babel-plugin-transform-builtin-classes to allow ex…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -512,6 +512,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -556,7 +557,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -1039,6 +1041,17 @@
         "babel-helper-remap-async-to-generator": "^6.24.1",
         "babel-plugin-syntax-async-functions": "^6.8.0",
         "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-builtin-classes": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-builtin-classes/-/babel-plugin-transform-builtin-classes-0.6.1.tgz",
+      "integrity": "sha512-UfOmEFTc9i7ERkp77xnxiAIxrHwYetl6KYa42itb3ENi98KEVPwZxApse4C19oD7CzcJUiFrII+zgB6cZij77w==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-runtime": "^6.23.0",
+        "babel-template": "^6.25.0"
       }
     },
     "babel-plugin-transform-class-constructor-call": {
@@ -1658,6 +1671,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -2509,6 +2523,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -2715,6 +2730,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -3915,6 +3931,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -4989,7 +5006,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jscodeshift": {
       "version": "0.5.1",
@@ -7592,7 +7610,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sax": {
       "version": "1.2.4",
@@ -8016,6 +8035,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
       "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -8377,7 +8397,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
+    "babel-plugin-transform-builtin-classes": "^0.6.1",
     "babel-preset-env": "^1.7.0",
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",

--- a/webpack.config.commonjs2.js
+++ b/webpack.config.commonjs2.js
@@ -17,6 +17,9 @@ const config = {
                     loader: 'babel-loader',
                     options: {
                         presets: ['babel-preset-env'],
+                        plugins: [["babel-plugin-transform-builtin-classes", {
+                          "globals": ["Set"]
+                        }]],
                         babelrc: false
                     }
                 }


### PR DESCRIPTION
…tending Set in commonjs build

Currently, the following code fails 

```js
> const Flatten = require('flatten-js/dist/flatten.commonjs2')
> new Flatten.Polygon()
TypeError: Constructor Set requires 'new'
    at PlanarSet.Set (<anonymous>)
    at new PlanarSet (/home/jan/src/snap/story-editor/node_modules/flatten-js/dist/flatten.commonjs2.js:7111:116)
    at new Polygon (/home/jan/src/snap/story-editor/node_modules/flatten-js/dist/flatten.commonjs2.js:4918:26)
```

Due to [this babel issue](https://github.com/babel/babel/issues/4480) - babel is not extending or initializing classes correctly when extending built-ins.

This should be fixed in babel 7, but I figured the easiest way was to use the plugin for babel 6 instead.

Tested locally, and with this change you can actually instantiate `Polygon` (and other stuff using `PlanarSet`) :)

I didn't update the dist folder since I figure you do that as part of the release process.