### PR TITLE
Fix typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -512,7 +512,7 @@ declare namespace Flatten {
 
     class MultilineEdge extends Edge {
         shape: MultilineEdgeShape;          // there may be only one line edge and only terminal ray edges
-        constructor(MultilineEdgeShape);
+        constructor(shape: MultilineEdgeShape);
     }
 
     class Multiline extends LinkedList {
@@ -538,7 +538,7 @@ declare namespace Flatten {
     type Shape = Point | Line | Ray | Circle | Box | Segment | Arc | Polygon;
 
     function point(x?: number, y?: number): Point;
-    function point(arr?: [number, number]);
+    function point(arr?: [number, number]): Point;
     function circle(pc: Point, r: number) : Circle;
     function line(pt?: Point, norm?: Vector) : Line;
     function line(norm?: Vector, pt?: Point) : Line;


### PR DESCRIPTION
Typescript otherwise complains in my setup:
```
515:21 Parameter 'MultilineEdgeShape' implicitly has an 'any' type.
    513 |     class MultilineEdge extends Edge {
    514 |         shape: MultilineEdgeShape;          // there may be only one line edge and only terminal ray edges
  > 515 |         constructor(MultilineEdgeShape);
        |                     ^
    516 |     }
    517 |
    518 |     class Multiline extends LinkedList {
541:14 'point', which lacks return-type annotation, implicitly has an 'any' return type.
    539 |
    540 |     function point(x?: number, y?: number): Point;
  > 541 |     function point(arr?: [number, number]);
        |              ^
    542 |     function circle(pc: Point, r: number) : Circle;
    543 |     function line(pt?: Point, norm?: Vector) : Line;
    544 |     function line(norm?: Vector, pt?: Point) : Line;
```