### PR TITLE
Reverse arc direction when reflecting over a single axis

### DIFF
--- a/src/classes/arc.js
+++ b/src/classes/arc.js
@@ -414,7 +414,11 @@ export class Arc {
         let newStart = this.start.transform(matrix);
         let newEnd = this.end.transform(matrix);
         let newCenter = this.pc.transform(matrix);
-        let arc = Flatten.Arc.arcSE(newCenter, newStart, newEnd, this.counterClockwise);
+        let newDirection = this.counterClockwise;
+        if (matrix.a * matrix.d < 0) {
+          newDirection = !newDirection;
+        }
+        let arc = Flatten.Arc.arcSE(newCenter, newStart, newEnd, newDirection);
         return arc;
     }
 


### PR DESCRIPTION
When applying a "mirror" affine transform on an arc, the direction of the arc should change. This addresses an issue we were seeing in this limited case; obviously a more robust support of affine transforms in arcs would require support for ellipses.