### PR TITLE
add types to Inversion.inverse parameters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -546,9 +546,9 @@ declare namespace Flatten {
         circle: Circle;              // inversion circle
         constructor(circle: Circle);
         get inversion_circle() : Circle;
-        inverse(Point) : Point;
-        inverse(Line) : Line | Circle;
-        inverse(Circle) : Line | Circle;
+        inverse(Point: Point) : Point;
+        inverse(Line: Line) : Line | Circle;
+        inverse(Circle: Circle) : Line | Circle;
     }
 
     type Shape = Point | Line | Ray | Circle | Box | Segment | Arc | Polygon;


### PR DESCRIPTION
With v1.3.0, I'm getting TypeScript build failures when noImplicitAny is set to true.

```
node_modules/@flatten-js/core/index.d.ts:549:17 - error TS7006: Parameter 'Point' implicitly has an 'any' type.

549         inverse(Point) : Point;
                    ~~~~~

node_modules/@flatten-js/core/index.d.ts:550:17 - error TS7006: Parameter 'Line' implicitly has an 'any' type.

550         inverse(Line) : Line | Circle;
                    ~~~~

node_modules/@flatten-js/core/index.d.ts:551:17 - error TS7006: Parameter 'Circle' implicitly has an 'any' type.

551         inverse(Circle) : Line | Circle;
```

This PR adds explicit type annotations to the parameters for `Inversion.inverse`

Thanks for your hard work on this package!