### PR TITLE
return an instance of the current class when calling clone/translate/…

### DIFF
--- a/src/classes/arc.js
+++ b/src/classes/arc.js
@@ -75,7 +75,7 @@ export class Arc {
      * @returns {Arc}
      */
     clone() {
-        return new Flatten.Arc(this.pc.clone(), this.r, this.startAngle, this.endAngle, this.counterClockwise);
+        return new this.constructor(this.pc.clone(), this.r, this.startAngle, this.endAngle, this.counterClockwise);
     }
 
     /**
@@ -192,8 +192,8 @@ export class Arc {
         let angle = new Flatten.Vector(this.pc, pt).slope;
 
         return [
-            new Flatten.Arc(this.pc, this.r, this.startAngle, angle, this.counterClockwise),
-            new Flatten.Arc(this.pc, this.r, angle, this.endAngle, this.counterClockwise)
+            new this.constructor(this.pc, this.r, this.startAngle, angle, this.counterClockwise),
+            new this.constructor(this.pc, this.r, angle, this.endAngle, this.counterClockwise)
         ]
     }
 
@@ -251,7 +251,7 @@ export class Arc {
         if (shape instanceof Flatten.Box) {
             return Intersection.intersectArc2Box(this, shape);
         }
-        if (shape instanceof Flatten.Arc) {
+        if (shape instanceof Arc) {
             return Intersection.intersectArc2Arc(this, shape);
         }
         if (shape instanceof Flatten.Polygon) {
@@ -289,7 +289,7 @@ export class Arc {
             return [dist, shortest_segment];
         }
 
-        if (shape instanceof Flatten.Arc) {
+        if (shape instanceof Arc) {
             let [dist, shortest_segment] = Flatten.Distance.arc2arc(this, shape);
             return [dist, shortest_segment];
         }
@@ -338,9 +338,9 @@ export class Arc {
                 let prev_arc = func_arcs_array.length > 0 ? func_arcs_array[func_arcs_array.length - 1] : undefined;
                 let new_arc;
                 if (prev_arc) {
-                    new_arc = new Flatten.Arc(this.pc, this.r, prev_arc.endAngle, test_arcs[i].endAngle, this.counterClockwise);
+                    new_arc = new this.constructor(this.pc, this.r, prev_arc.endAngle, test_arcs[i].endAngle, this.counterClockwise);
                 } else {
-                    new_arc = new Flatten.Arc(this.pc, this.r, this.startAngle, test_arcs[i].endAngle, this.counterClockwise);
+                    new_arc = new this.constructor(this.pc, this.r, this.startAngle, test_arcs[i].endAngle, this.counterClockwise);
                 }
                 if (!Flatten.Utils.EQ_0(new_arc.length)) {
                     func_arcs_array.push(new_arc.clone());
@@ -351,9 +351,9 @@ export class Arc {
             let prev_arc = func_arcs_array.length > 0 ? func_arcs_array[func_arcs_array.length - 1] : undefined;
             let new_arc;
             if (prev_arc) {
-                new_arc = new Flatten.Arc(this.pc, this.r, prev_arc.endAngle, this.endAngle, this.counterClockwise);
+                new_arc = new this.constructor(this.pc, this.r, prev_arc.endAngle, this.endAngle, this.counterClockwise);
             } else {
-                new_arc = new Flatten.Arc(this.pc, this.r, this.startAngle, this.endAngle, this.counterClockwise);
+                new_arc = new this.constructor(this.pc, this.r, this.startAngle, this.endAngle, this.counterClockwise);
             }
             // It could be 2*PI when occasionally start = 0 and end = 2*PI but this is not valid for breakToFunctional
             if (!Flatten.Utils.EQ_0(new_arc.length) && !Flatten.Utils.EQ(new_arc.sweep, 2*Math.PI)) {
@@ -390,7 +390,7 @@ export class Arc {
      * @returns {Arc}
      */
     reverse() {
-        return new Flatten.Arc(this.pc, this.r, this.endAngle, this.startAngle, !this.counterClockwise);
+        return new this.constructor(this.pc, this.r, this.endAngle, this.startAngle, !this.counterClockwise);
     }
 
     /**
@@ -447,7 +447,7 @@ export class Arc {
         if (matrix.a * matrix.d < 0) {
           newDirection = !newDirection;
         }
-        let arc = Flatten.Arc.arcSE(newCenter, newStart, newEnd, newDirection);
+        let arc = this.constructor.arcSE(newCenter, newStart, newEnd, newDirection);
         return arc;
     }
 
@@ -461,7 +461,7 @@ export class Arc {
         }
         let r = vector(center, start).length;
 
-        return new Flatten.Arc(center, r, startAngle, endAngle, counterClockwise);
+        return new this(center, r, startAngle, endAngle, counterClockwise);
     }
 
     definiteIntegral(ymin = 0) {

--- a/src/classes/box.js
+++ b/src/classes/box.js
@@ -45,7 +45,7 @@ export class Box {
      * @returns {Box}
      */
     clone() {
-        return new Box(this.xmin, this.ymin, this.xmax, this.ymax);
+        return new this.constructor(this.xmin, this.ymin, this.xmax, this.ymax);
     }
 
     /**
@@ -133,7 +133,7 @@ export class Box {
      * @returns {Box}
      */
     merge(other_box) {
-        return new Box(
+        return new this.constructor(
             this.xmin === undefined ? other_box.xmin : Math.min(this.xmin, other_box.xmin),
             this.ymin === undefined ? other_box.ymin : Math.min(this.ymin, other_box.ymin),
             this.xmax === undefined ? other_box.xmax : Math.max(this.xmax, other_box.xmax),

--- a/src/classes/circle.js
+++ b/src/classes/circle.js
@@ -49,7 +49,7 @@ export class Circle {
      * @returns {Circle}
      */
     clone() {
-        return new Flatten.Circle(this.pc.clone(), this.r);
+        return new this.constructor(this.pc.clone(), this.r);
     }
 
     /**
@@ -94,7 +94,7 @@ export class Circle {
                 Flatten.Utils.LE(shape.end.distanceTo(this.center)[0], this.r);
         }
 
-        if (shape instanceof Flatten.Circle) {
+        if (shape instanceof Constructor) {
             return this.intersect(shape).length === 0 &&
                 Flatten.Utils.LE(shape.r, this.r) &&
                 Flatten.Utils.LE(shape.center.distanceTo(this.center)[0], this.r);
@@ -129,7 +129,7 @@ export class Circle {
             return Intersection.intersectSegment2Circle(shape, this);
         }
 
-        if (shape instanceof Flatten.Circle) {
+        if (shape instanceof Circle) {
             return Intersection.intersectCircle2Circle(shape, this);
         }
 
@@ -159,7 +159,7 @@ export class Circle {
             return [distance, shortest_segment];
         }
 
-        if (shape instanceof Flatten.Circle) {
+        if (shape instanceof Circle) {
             let [distance, shortest_segment] = Flatten.Distance.circle2circle(this, shape);
             return [distance, shortest_segment];
         }

--- a/src/classes/line.js
+++ b/src/classes/line.js
@@ -91,7 +91,7 @@ export class Line {
      * @returns {Line}
      */
     clone() {
-        return new Flatten.Line(this.pt, this.norm);
+        return new this.constructor(this.pt, this.norm);
     }
 
     /* The following methods need for implementation of Edge interface
@@ -207,7 +207,7 @@ export class Line {
             return this.contains(shape) ? [shape] : [];
         }
 
-        if (shape instanceof Flatten.Line) {
+        if (shape instanceof Line) {
             return Intersection.intersectLine2Line(this, shape);
         }
 

--- a/src/classes/matrix.js
+++ b/src/classes/matrix.js
@@ -36,7 +36,7 @@ export class Matrix {
      * @return {Matrix}
      **/
     clone() {
-        return new Matrix(this.a, this.b, this.c, this.d, this.tx, this.ty);
+        return new this.constructor(this.a, this.b, this.c, this.d, this.tx, this.ty);
     };
 
     /**
@@ -64,7 +64,7 @@ export class Matrix {
      * @returns {Matrix}
      */
     multiply(other_matrix) {
-        return new Matrix(
+        return new this.constructor(
             this.a * other_matrix.a + this.c * other_matrix.b,
             this.b * other_matrix.a + this.d * other_matrix.b,
             this.a * other_matrix.c + this.c * other_matrix.d,
@@ -92,7 +92,7 @@ export class Matrix {
         } else {
             throw Flatten.Errors.ILLEGAL_PARAMETERS;
         }
-        return this.multiply(new Matrix(1, 0, 0, 1, tx, ty))
+        return this.multiply(new this.constructor(1, 0, 0, 1, tx, ty))
     };
 
     /**
@@ -105,7 +105,7 @@ export class Matrix {
     rotate(angle) {
         let cos = Math.cos(angle);
         let sin = Math.sin(angle);
-        return this.multiply(new Matrix(cos, sin, -sin, cos, 0, 0));
+        return this.multiply(new this.constructor(cos, sin, -sin, cos, 0, 0));
     };
 
     /**
@@ -116,7 +116,7 @@ export class Matrix {
      * @returns {Matrix}
      */
     scale(sx, sy) {
-        return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
+        return this.multiply(new this.constructor(sx, 0, 0, sy, 0, 0));
     };
 
     /**

--- a/src/classes/multiline.js
+++ b/src/classes/multiline.js
@@ -71,7 +71,7 @@ export class Multiline extends LinkedList {
      * @returns {Multiline}
      */
     clone() {
-        return new Multiline(this.toShapes());
+        return new this.constructor(this.toShapes());
     }
 
     /**
@@ -137,7 +137,7 @@ export class Multiline extends LinkedList {
      * @returns {Multiline}
      */
     translate(vec) {
-        return new Multiline(this.edges.map( edge => edge.shape.translate(vec)));
+        return new this.constructor(this.edges.map( edge => edge.shape.translate(vec)));
     }
 
     /**
@@ -149,7 +149,7 @@ export class Multiline extends LinkedList {
      * @returns {Multiline} - new rotated polygon
      */
     rotate(angle = 0, center = new Flatten.Point()) {
-        return new Multiline(this.edges.map( edge => edge.shape.rotate(angle, center) ));
+        return new this.constructor(this.edges.map( edge => edge.shape.rotate(angle, center) ));
     }
 
     /**
@@ -159,7 +159,7 @@ export class Multiline extends LinkedList {
      * @returns {Multiline} - new multiline
      */
     transform(matrix = new Flatten.Matrix()) {
-        return new Multiline(this.edges.map( edge => edge.shape.transform(matrix)));
+        return new this.constructor(this.edges.map( edge => edge.shape.transform(matrix)));
     }
 
     /**

--- a/src/classes/point.js
+++ b/src/classes/point.js
@@ -72,7 +72,7 @@ export class Point {
      * @returns {Point}
      */
     clone() {
-        return new Flatten.Point(this.x, this.y);
+        return new this.constructor(this.x, this.y);
     }
 
     get vertices() {
@@ -116,7 +116,7 @@ export class Point {
         var x_rot = center.x + (this.x - center.x) * Math.cos(angle) - (this.y - center.y) * Math.sin(angle);
         var y_rot = center.y + (this.x - center.x) * Math.sin(angle) + (this.y - center.y) * Math.cos(angle);
 
-        return new Flatten.Point(x_rot, y_rot);
+        return new this.constructor(x_rot, y_rot);
     }
 
     /**
@@ -129,11 +129,11 @@ export class Point {
     translate(...args) {
         if (args.length == 1 &&
             (args[0] instanceof Flatten.Vector || !isNaN(args[0].x) && !isNaN(args[0].y))) {
-            return new Flatten.Point(this.x + args[0].x, this.y + args[0].y);
+            return new this.constructor(this.x + args[0].x, this.y + args[0].y);
         }
 
         if (args.length == 2 && typeof (args[0]) == "number" && typeof (args[1]) == "number") {
-            return new Flatten.Point(this.x + args[0], this.y + args[1]);
+            return new this.constructor(this.x + args[0], this.y + args[1]);
         }
 
         throw Flatten.Errors.ILLEGAL_PARAMETERS;
@@ -146,7 +146,7 @@ export class Point {
      */
     transform(m) {
         // let [x,y] = m.transform([this.x,this.y]);
-        return new Flatten.Point(m.transform([this.x, this.y]))
+        return new this.constructor(m.transform([this.x, this.y]))
     }
 
     /**
@@ -227,7 +227,7 @@ export class Point {
      * @returns {boolean}
      */
     on(shape) {
-        if (shape instanceof Flatten.Point) {
+        if (shape instanceof Point) {
             return this.equalTo(shape);
         }
 

--- a/src/classes/polygon.js
+++ b/src/classes/polygon.js
@@ -106,7 +106,7 @@ export class Polygon {
      * @returns {Polygon}
      */
     clone() {
-        let polygon = new Polygon();
+        let polygon = new this.constructor();
         for (let face of this.faces) {
             polygon.addFace(face.shapes);
         }
@@ -547,7 +547,7 @@ export class Polygon {
         }
 
         /* this method is bit faster */
-        if (shape instanceof Flatten.Polygon) {
+        if (shape instanceof Polygon) {
             let min_dist_and_segment = [Number.POSITIVE_INFINITY, new Flatten.Segment()];
             let dist, shortest_segment;
 
@@ -589,7 +589,7 @@ export class Polygon {
             return Intersection.intersectArc2Polygon(shape, this);
         }
 
-        if (shape instanceof Flatten.Polygon) {
+        if (shape instanceof Polygon) {
             return Intersection.intersectPolygon2Polygon(shape, this);
         }
     }
@@ -600,7 +600,7 @@ export class Polygon {
      * @returns {Polygon}
      */
     translate(vec) {
-        let newPolygon = new Polygon();
+        let newPolygon = new this.constructor();
         for (let face of this.faces) {
             newPolygon.addFace(face.shapes.map(shape => shape.translate(vec)));
         }
@@ -616,7 +616,7 @@ export class Polygon {
      * @returns {Polygon} - new rotated polygon
      */
     rotate(angle = 0, center = new Flatten.Point()) {
-        let newPolygon = new Polygon();
+        let newPolygon = new this.constructor();
         for (let face of this.faces) {
             newPolygon.addFace(face.shapes.map(shape => shape.rotate(angle, center)));
         }
@@ -629,7 +629,7 @@ export class Polygon {
      * @returns {Polygon} - new polygon
      */
     transform(matrix = new Flatten.Matrix()) {
-        let newPolygon = new Polygon();
+        let newPolygon = new this.constructor();
         for (let face of this.faces) {
             newPolygon.addFace(face.shapes.map(shape => shape.transform(matrix)));
         }

--- a/src/classes/ray.js
+++ b/src/classes/ray.js
@@ -52,7 +52,7 @@ export class Ray {
      * @returns {Ray}
      */
     clone() {
-        return new Ray(this.pt, this.norm);
+        return new this.constructor(this.pt, this.norm);
     }
 
     /**
@@ -128,7 +128,7 @@ export class Ray {
 
         return [
             new Flatten.Segment(this.pt, pt),
-            new Flatten.Ray(pt, this.norm)
+            new this.constructor(pt, this.norm)
         ]
     }
 

--- a/src/classes/segment.js
+++ b/src/classes/segment.js
@@ -73,7 +73,7 @@ export class Segment {
      * @returns {Segment}
      */
     clone() {
-        return new Flatten.Segment(this.start, this.end);
+        return new this.constructor(this.start, this.end);
     }
 
     /**
@@ -163,7 +163,7 @@ export class Segment {
             return Intersection.intersectSegment2Line(this, shape);
         }
 
-        if (shape instanceof Flatten.Segment) {
+        if (shape instanceof Segment) {
             return  Intersection.intersectSegment2Segment(this, shape);
         }
 
@@ -207,7 +207,7 @@ export class Segment {
             return [dist, shortest_segment];
         }
 
-        if (shape instanceof Flatten.Segment) {
+        if (shape instanceof Segment) {
             let [dist, shortest_segment] = Flatten.Distance.segment2segment(this, shape);
             return [dist, shortest_segment];
         }
@@ -251,7 +251,7 @@ export class Segment {
      * @returns {Segment}
      */
     reverse() {
-        return new Segment(this.end, this.start);
+        return new this.constructor(this.end, this.start);
     }
 
     /**
@@ -269,8 +269,8 @@ export class Segment {
             return [this.clone(), null];
 
         return [
-            new Flatten.Segment(this.start, pt),
-            new Flatten.Segment(pt, this.end)
+            new this.constructor(this.start, pt),
+            new this.constructor(pt, this.end)
         ]
     }
 
@@ -316,7 +316,7 @@ export class Segment {
      * @returns {Segment}
      */
     translate(...args) {
-        return new Segment(this.ps.translate(...args), this.pe.translate(...args));
+        return new this.constructor(this.ps.translate(...args), this.pe.translate(...args));
     }
 
     /**
@@ -339,7 +339,7 @@ export class Segment {
      * @returns {Segment} - transformed segment
      */
     transform(matrix = new Flatten.Matrix()) {
-        return new Segment(this.ps.transform(matrix), this.pe.transform(matrix))
+        return new this.constructor(this.ps.transform(matrix), this.pe.transform(matrix))
     }
 
     /**

--- a/src/classes/vector.js
+++ b/src/classes/vector.js
@@ -76,7 +76,7 @@ export class Vector {
      * @returns {Vector}
      */
     clone() {
-        return new Flatten.Vector(this.x, this.y);
+        return new this.constructor(this.x, this.y);
     }
 
     /**
@@ -113,7 +113,7 @@ export class Vector {
      * @returns {Vector}
      */
     multiply(scalar) {
-        return (new Flatten.Vector(scalar * this.x, scalar * this.y));
+        return (new this.constructor(scalar * this.x, scalar * this.y));
     }
 
     /**
@@ -143,7 +143,7 @@ export class Vector {
      */
     normalize() {
         if (!Flatten.Utils.EQ_0(this.length)) {
-            return (new Flatten.Vector(this.x / this.length, this.y / this.length));
+            return (new this.constructor(this.x / this.length, this.y / this.length));
         }
         throw Flatten.Errors.ZERO_DIVISION;
     }
@@ -158,7 +158,7 @@ export class Vector {
     rotate(angle) {
         let point = new Flatten.Point(this.x, this.y);
         let rpoint = point.rotate(angle);
-        return new Flatten.Vector(rpoint.x, rpoint.y);
+        return new this.constructor(rpoint.x, rpoint.y);
     }
 
     /**
@@ -166,7 +166,7 @@ export class Vector {
      * @returns {Vector}
      */
     rotate90CCW() {
-        return new Flatten.Vector(-this.y, this.x);
+        return new this.constructor(-this.y, this.x);
     };
 
     /**
@@ -174,7 +174,7 @@ export class Vector {
      * @returns {Vector}
      */
     rotate90CW() {
-        return new Flatten.Vector(this.y, -this.x);
+        return new this.constructor(this.y, -this.x);
     };
 
     /**
@@ -182,7 +182,7 @@ export class Vector {
      * @returns {Vector}
      */
     invert() {
-        return new Flatten.Vector(-this.x, -this.y);
+        return new this.constructor(-this.x, -this.y);
     }
 
     /**
@@ -191,7 +191,7 @@ export class Vector {
      * @returns {Vector}
      */
     add(v) {
-        return new Flatten.Vector(this.x + v.x, this.y + v.y);
+        return new this.constructor(this.x + v.x, this.y + v.y);
     }
 
     /**
@@ -200,7 +200,7 @@ export class Vector {
      * @returns {Vector}
      */
     subtract(v) {
-        return new Flatten.Vector(this.x - v.x, this.y - v.y);
+        return new this.constructor(this.x - v.x, this.y - v.y);
     }
 
     /**

--- a/test/inheritance.js
+++ b/test/inheritance.js
@@ -1,0 +1,73 @@
+"use strict";
+
+import { expect } from "chai";
+import Flatten from "../index";
+
+describe("#Flatten.inheritance", function () {
+  class Arc extends Flatten.Arc {}
+  class Box extends Flatten.Box {}
+  class Circle extends Flatten.Circle {}
+  class Line extends Flatten.Line {}
+  class Matrix extends Flatten.Matrix {}
+  class Multiline extends Flatten.Multiline {}
+  class Point extends Flatten.Point {}
+  class Polygon extends Flatten.Polygon {}
+  class Ray extends Flatten.Ray {}
+  class Segment extends Flatten.Segment {}
+  class Vector extends Flatten.Vector {}
+
+  const testClasses = {
+    Arc,
+    Box,
+    Circle,
+    Line,
+    Matrix,
+    Multiline,
+    Point,
+    Polygon,
+    Ray,
+    Segment,
+    Vector,
+  };
+
+  for (let className in testClasses) {
+    it(`allows ${className} inheritance`, function () {
+      const theClass = testClasses[className];
+      const instance = new theClass();
+      expect(instance.clone()).to.be.instanceof(theClass);
+      if (instance.translate) {
+        expect(instance.translate(new Vector(1, 1))).to.be.instanceof(theClass);
+      }
+      if (instance.merge) {
+        expect(instance.merge(instance.clone())).to.be.instanceof(theClass);
+      }
+      if (instance.rotate) {
+        expect(instance.rotate(Math.PI)).to.be.instanceof(theClass);
+      }
+      // Matrix.transform() expects Vector
+      if (instance.transform && className != "Matrix") {
+        expect(instance.transform(Flatten.matrix())).to.be.instanceof(theClass);
+      }
+    });
+  }
+
+  it("allows deep inheritance", function () {
+    const center = new Point();
+    const arc = new Arc(center);
+    expect(arc.clone().pc).to.be.instanceof(Point);
+    const segment = new Segment(new Point(10, 10), new Point(20, 10));
+    expect(segment.end).to.be.instanceof(Point);
+    expect(segment.clone().end).to.be.instanceof(Point);
+    const poly = new Polygon([arc, segment]);
+    let instance = poly.clone();
+    for (let edge of instance.edges) {
+      if (edge.shape instanceof Flatten.Segment) {
+        expect(edge.shape).to.be.instanceof(Segment);
+        expect(edge.shape.end).to.be.instanceof(Point);
+      } else {
+        expect(edge.shape).to.be.instanceof(Arc);
+        expect(edge.shape.pc).to.be.instanceof(Point);
+      }
+    }
+  });
+});


### PR DESCRIPTION
this allows to use extended classes with  methods like clone/translate/rotate/transform/merge

a basic example

```js
class Arc extends Flatten.Arc {
  customMethod() {/*...*/}
}
class Segment extends Flatten.Segment {
  customMethod() {/*...*/}
}
class Polygon exnteds Flatten.Polygon {
  customMethod() {/*...*/}
}

const poly = new Polygon([new Arc(), new Segment()])
// not working now
poly.clone().customMethod()

for (let edge of polygon.translate(Flatten.vector(1, 1)).edges) {
  // not working now
  edge.shape.customMethod()
}
```