### PR TITLE
Typescript: add scale to declared Polygon functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -548,6 +548,7 @@ declare namespace Flatten {
         distanceTo(shape: AnyShape): [number, Segment];
         intersect(shape: AnyShape): Point[];
         rotate(angle?: number, center?: Point): Polygon;
+        scale(sx: number, sy: number): Polygon;
         transform(matrix?: Matrix): Polygon;
         translate(vec: Vector): Polygon;
         toJSON() : Object;


### PR DESCRIPTION
Typescript file missing declaration for `Polygon.scale`. Added it in to match spec in docs.