### PR TITLE
Fix polygon.cut error

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -395,6 +395,271 @@ class LinkedList {
     }
 }
 
+const defaultAttributes = {
+    stroke: "black"
+};
+
+class SVGAttributes {
+    constructor(args = defaultAttributes) {
+        for(const property in args) {
+            this[property] = args[property];
+        }
+        this.stroke = args.stroke ?? defaultAttributes.stroke;
+    }
+
+    toAttributesString() {
+        return Object.keys(this)
+            .reduce( (acc, key) =>
+                    acc + (this[key] !== undefined ? this.toAttrString(key, this[key]) : "")
+            , ``)
+    }
+
+    toAttrString(key, value) {
+        const SVGKey = key === "className" ? "class" : this.convertCamelToKebabCase(key);
+        return value === null ? `${SVGKey} ` : `${SVGKey}="${value.toString()}" `
+    }
+
+    convertCamelToKebabCase(str) {
+        return str
+            .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
+            .join('-')
+            .toLowerCase();
+    }
+}
+
+function convertToString(attrs) {
+    return new SVGAttributes(attrs).toAttributesString()
+}
+
+/**
+ * Class Multiline represent connected path of [edges]{@link Flatten.Edge}, where each edge may be
+ * [segment]{@link Flatten.Segment}, [arc]{@link Flatten.Arc}, [line]{@link Flatten.Line} or [ray]{@link Flatten.Ray}
+ */
+class Multiline extends LinkedList {
+    constructor(...args) {
+        super();
+
+        if (args.length === 0) {
+            return;
+        }
+
+        if (args.length === 1) {
+            if (args[0] instanceof Array) {
+                let shapes = args[0];
+                if (shapes.length === 0)
+                    return;
+
+                // TODO: more strict validation:
+                // there may be only one line
+                // only first and last may be rays
+                shapes.every((shape) => {
+                    return shape instanceof Flatten.Segment ||
+                        shape instanceof Flatten.Arc ||
+                        shape instanceof Flatten.Ray ||
+                        shape instanceof Flatten.Line
+                });
+
+                for (let shape of shapes) {
+                    let edge = new Flatten.Edge(shape);
+                    this.append(edge);
+                }
+
+                this.setArcLength();
+            }
+        }
+    }
+
+    /**
+     * (Getter) Return array of edges
+     * @returns {Edge[]}
+     */
+    get edges() {
+        return [...this];
+    }
+
+    /**
+     * (Getter) Return bounding box of the multiline
+     * @returns {Box}
+     */
+    get box() {
+        return this.edges.reduce( (acc,edge) => acc.merge(edge.box), new Flatten.Box() );
+    }
+
+    /**
+     * (Getter) Returns array of vertices
+     * @returns {Point[]}
+     */
+    get vertices() {
+        let v = this.edges.map(edge => edge.start);
+        v.push(this.last.end);
+        return v;
+    }
+
+    /**
+     * Return new cloned instance of Multiline
+     * @returns {Multiline}
+     */
+    clone() {
+        return new Multiline(this.toShapes());
+    }
+
+    /**
+     * Set arc_length property for each of the edges in the face.
+     * Arc_length of the edge it the arc length from the first edge of the face
+     */
+    setArcLength() {
+        for (let edge of this) {
+            this.setOneEdgeArcLength(edge);
+        }
+    }
+
+    setOneEdgeArcLength(edge) {
+        if (edge === this.first) {
+            edge.arc_length = 0.0;
+        } else {
+            edge.arc_length = edge.prev.arc_length + edge.prev.length;
+        }
+    }
+
+    /**
+     * Split edge and add new vertex, return new edge inserted
+     * @param {Point} pt - point on edge that will be added as new vertex
+     * @param {Edge} edge - edge to split
+     * @returns {Edge}
+     */
+    addVertex(pt, edge) {
+        let shapes = edge.shape.split(pt);
+        // if (shapes.length < 2) return;
+
+        if (shapes[0] === null)   // point incident to edge start vertex, return previous edge
+           return edge.prev;
+
+        if (shapes[1] === null)   // point incident to edge end vertex, return edge itself
+           return edge;
+
+        let newEdge = new Flatten.Edge(shapes[0]);
+        let edgeBefore = edge.prev;
+
+        /* Insert first split edge into linked list after edgeBefore */
+        this.insert(newEdge, edgeBefore);     // edge.face ?
+
+        // Update edge shape with second split edge keeping links
+        edge.shape = shapes[1];
+
+        return newEdge;
+    }
+
+    getChain(edgeFrom, edgeTo) {
+        let edges = [];
+        for (let edge = edgeFrom; edge !== edgeTo.next; edge = edge.next) {
+            edges.push(edge);
+        }
+        return edges
+    }
+
+    /**
+     * Split edges of multiline with intersection points and return mutated multiline
+     * @param {Point[]} ip - array of points to be added as new vertices
+     * @returns {Multiline}
+     */
+    split(ip) {
+        for (let pt of ip) {
+            let edge = this.findEdgeByPoint(pt);
+            this.addVertex(pt, edge);
+        }
+        return this;
+    }
+
+    /**
+     * Returns edge which contains given point
+     * @param {Point} pt
+     * @returns {Edge}
+     */
+    findEdgeByPoint(pt) {
+        let edgeFound;
+        for (let edge of this) {
+            if (edge.shape.contains(pt)) {
+                edgeFound = edge;
+                break;
+            }
+        }
+        return edgeFound;
+    }
+
+    /**
+     * Returns new multiline translated by vector vec
+     * @param {Vector} vec
+     * @returns {Multiline}
+     */
+    translate(vec) {
+        return new Multiline(this.edges.map( edge => edge.shape.translate(vec)));
+    }
+
+    /**
+     * Return new multiline rotated by given angle around given point
+     * If point omitted, rotate around origin (0,0)
+     * Positive value of angle defines rotation counterclockwise, negative - clockwise
+     * @param {number} angle - rotation angle in radians
+     * @param {Point} center - rotation center, default is (0,0)
+     * @returns {Multiline} - new rotated polygon
+     */
+    rotate(angle = 0, center = new Flatten.Point()) {
+        return new Multiline(this.edges.map( edge => edge.shape.rotate(angle, center) ));
+    }
+
+    /**
+     * Return new multiline transformed using affine transformation matrix
+     * Method does not support unbounded shapes
+     * @param {Matrix} matrix - affine transformation matrix
+     * @returns {Multiline} - new multiline
+     */
+    transform(matrix = new Flatten.Matrix()) {
+        return new Multiline(this.edges.map( edge => edge.shape.transform(matrix)));
+    }
+
+    /**
+     * Transform multiline into array of shapes
+     * @returns {Shape[]}
+     */
+    toShapes() {
+        return this.edges.map(edge => edge.shape.clone())
+    }
+
+    /**
+     * This method returns an object that defines how data will be
+     * serialized when called JSON.stringify() method
+     * @returns {Object}
+     */
+    toJSON() {
+        return this.edges.map(edge => edge.toJSON());
+    }
+
+    /**
+     * Return string to draw multiline in svg
+     * @param attrs  - an object with attributes for svg path element
+     * TODO: support semi-infinite Ray and infinite Line
+     * @returns {string}
+     */
+    svg(attrs = {}) {
+        let svgStr = `\n<path ${convertToString({fill: "none", ...attrs})} d="`;
+        svgStr += `\nM${this.first.start.x},${this.first.start.y}`;
+        for (let edge of this) {
+            svgStr += edge.svg();
+        }
+        svgStr += `" >\n</path>`;
+        return svgStr;
+    }
+}
+
+Flatten.Multiline = Multiline;
+
+/**
+ * Shortcut function to create multiline
+ * @param args
+ */
+const multiline = (...args) => new Flatten.Multiline(...args);
+Flatten.multiline = multiline;
+
 /*
     Smart intersections describe intersection points that refers to the edges they intersect
     This function are supposed for internal usage by morphing and relation methods between
@@ -450,11 +715,7 @@ function addToIntPoints(edge, pt, int_points)
 
 function sortIntersections(intersections)
 {
-    // if (intersections.int_points1.length === 0) return;
-
     // augment intersections with new sorted arrays
-    // intersections.int_points1_sorted = intersections.int_points1.slice().sort(compareFn);
-    // intersections.int_points2_sorted = intersections.int_points2.slice().sort(compareFn);
     intersections.int_points1_sorted = getSortedArray(intersections.int_points1);
     intersections.int_points2_sorted = getSortedArray(intersections.int_points2);
 }
@@ -497,18 +758,6 @@ function compareFn(ip1, ip2)
     }
     return 0;
 }
-
-// export function getSortedArrayOnLine(line, int_points) {
-//     return int_points.slice().sort( (int_point1, int_point2) => {
-//         if (line.coord(int_point1.pt) < line.coord(int_point2.pt)) {
-//             return -1;
-//         }
-//         if (line.coord(int_point1.pt) > line.coord(int_point2.pt)) {
-//             return 1;
-//         }
-//         return 0;
-//     })
-// }
 
 function filterDuplicatedIntersections(intersections)
 {
@@ -741,14 +990,10 @@ function splitByIntersections(polygon, int_points)
             int_point.is_vertex |= END_VERTEX$1;
         }
 
-        if (int_point.is_vertex & START_VERTEX$1) {  // nothing to split
+        if (int_point.is_vertex & START_VERTEX$1) {    // nothing to split
+            int_point.edge_before = edge.prev;
             if (edge.prev) {
-                int_point.edge_before = edge.prev;           // polygon
-                int_point.is_vertex = END_VERTEX$1;
-            }
-            else {                                           // multiline start vertex
-                int_point.edge_after = int_point.edge_before;
-                int_point.edge_before = edge.prev;
+                int_point.is_vertex = END_VERTEX$1;   // polygon
             }
             continue;
         }
@@ -763,6 +1008,11 @@ function splitByIntersections(polygon, int_points)
     for (let int_point of int_points) {
         if (int_point.edge_before) {
             int_point.edge_after = int_point.edge_before.next;
+        }
+        else {
+            if (polygon instanceof Multiline && int_point.is_vertex & START_VERTEX$1) {
+                int_point.edge_after = polygon.first;
+            }
         }
     }
 }
@@ -2298,271 +2548,6 @@ function intersectRay2Polygon(ray, polygon) {
     return intersectLine2Polygon(createLineFromRay(ray), polygon)
         .filter(pt => ray.contains(pt))
 }
-
-const defaultAttributes = {
-    stroke: "black"
-};
-
-class SVGAttributes {
-    constructor(args = defaultAttributes) {
-        for(const property in args) {
-            this[property] = args[property];
-        }
-        this.stroke = args.stroke ?? defaultAttributes.stroke;
-    }
-
-    toAttributesString() {
-        return Object.keys(this)
-            .reduce( (acc, key) =>
-                    acc + (this[key] !== undefined ? this.toAttrString(key, this[key]) : "")
-            , ``)
-    }
-
-    toAttrString(key, value) {
-        const SVGKey = key === "className" ? "class" : this.convertCamelToKebabCase(key);
-        return value === null ? `${SVGKey} ` : `${SVGKey}="${value.toString()}" `
-    }
-
-    convertCamelToKebabCase(str) {
-        return str
-            .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
-            .join('-')
-            .toLowerCase();
-    }
-}
-
-function convertToString(attrs) {
-    return new SVGAttributes(attrs).toAttributesString()
-}
-
-/**
- * Class Multiline represent connected path of [edges]{@link Flatten.Edge}, where each edge may be
- * [segment]{@link Flatten.Segment}, [arc]{@link Flatten.Arc}, [line]{@link Flatten.Line} or [ray]{@link Flatten.Ray}
- */
-class Multiline extends LinkedList {
-    constructor(...args) {
-        super();
-
-        if (args.length === 0) {
-            return;
-        }
-
-        if (args.length === 1) {
-            if (args[0] instanceof Array) {
-                let shapes = args[0];
-                if (shapes.length === 0)
-                    return;
-
-                // TODO: more strict validation:
-                // there may be only one line
-                // only first and last may be rays
-                shapes.every((shape) => {
-                    return shape instanceof Flatten.Segment ||
-                        shape instanceof Flatten.Arc ||
-                        shape instanceof Flatten.Ray ||
-                        shape instanceof Flatten.Line
-                });
-
-                for (let shape of shapes) {
-                    let edge = new Flatten.Edge(shape);
-                    this.append(edge);
-                }
-
-                this.setArcLength();
-            }
-        }
-    }
-
-    /**
-     * (Getter) Return array of edges
-     * @returns {Edge[]}
-     */
-    get edges() {
-        return [...this];
-    }
-
-    /**
-     * (Getter) Return bounding box of the multiline
-     * @returns {Box}
-     */
-    get box() {
-        return this.edges.reduce( (acc,edge) => acc.merge(edge.box), new Flatten.Box() );
-    }
-
-    /**
-     * (Getter) Returns array of vertices
-     * @returns {Point[]}
-     */
-    get vertices() {
-        let v = this.edges.map(edge => edge.start);
-        v.push(this.last.end);
-        return v;
-    }
-
-    /**
-     * Return new cloned instance of Multiline
-     * @returns {Multiline}
-     */
-    clone() {
-        return new Multiline(this.toShapes());
-    }
-
-    /**
-     * Set arc_length property for each of the edges in the face.
-     * Arc_length of the edge it the arc length from the first edge of the face
-     */
-    setArcLength() {
-        for (let edge of this) {
-            this.setOneEdgeArcLength(edge);
-        }
-    }
-
-    setOneEdgeArcLength(edge) {
-        if (edge === this.first) {
-            edge.arc_length = 0.0;
-        } else {
-            edge.arc_length = edge.prev.arc_length + edge.prev.length;
-        }
-    }
-
-    /**
-     * Split edge and add new vertex, return new edge inserted
-     * @param {Point} pt - point on edge that will be added as new vertex
-     * @param {Edge} edge - edge to split
-     * @returns {Edge}
-     */
-    addVertex(pt, edge) {
-        let shapes = edge.shape.split(pt);
-        // if (shapes.length < 2) return;
-
-        if (shapes[0] === null)   // point incident to edge start vertex, return previous edge
-           return edge.prev;
-
-        if (shapes[1] === null)   // point incident to edge end vertex, return edge itself
-           return edge;
-
-        let newEdge = new Flatten.Edge(shapes[0]);
-        let edgeBefore = edge.prev;
-
-        /* Insert first split edge into linked list after edgeBefore */
-        this.insert(newEdge, edgeBefore);     // edge.face ?
-
-        // Update edge shape with second split edge keeping links
-        edge.shape = shapes[1];
-
-        return newEdge;
-    }
-
-    getChain(edgeFrom, edgeTo) {
-        let edges = [];
-        for (let edge = edgeFrom; edge !== edgeTo.next; edge = edge.next) {
-            edges.push(edge);
-        }
-        return edges
-    }
-
-    /**
-     * Split edges of multiline with intersection points and return mutated multiline
-     * @param {Point[]} ip - array of points to be added as new vertices
-     * @returns {Multiline}
-     */
-    split(ip) {
-        for (let pt of ip) {
-            let edge = this.findEdgeByPoint(pt);
-            this.addVertex(pt, edge);
-        }
-        return this;
-    }
-
-    /**
-     * Returns edge which contains given point
-     * @param {Point} pt
-     * @returns {Edge}
-     */
-    findEdgeByPoint(pt) {
-        let edgeFound;
-        for (let edge of this) {
-            if (edge.shape.contains(pt)) {
-                edgeFound = edge;
-                break;
-            }
-        }
-        return edgeFound;
-    }
-
-    /**
-     * Returns new multiline translated by vector vec
-     * @param {Vector} vec
-     * @returns {Multiline}
-     */
-    translate(vec) {
-        return new Multiline(this.edges.map( edge => edge.shape.translate(vec)));
-    }
-
-    /**
-     * Return new multiline rotated by given angle around given point
-     * If point omitted, rotate around origin (0,0)
-     * Positive value of angle defines rotation counterclockwise, negative - clockwise
-     * @param {number} angle - rotation angle in radians
-     * @param {Point} center - rotation center, default is (0,0)
-     * @returns {Multiline} - new rotated polygon
-     */
-    rotate(angle = 0, center = new Flatten.Point()) {
-        return new Multiline(this.edges.map( edge => edge.shape.rotate(angle, center) ));
-    }
-
-    /**
-     * Return new multiline transformed using affine transformation matrix
-     * Method does not support unbounded shapes
-     * @param {Matrix} matrix - affine transformation matrix
-     * @returns {Multiline} - new multiline
-     */
-    transform(matrix = new Flatten.Matrix()) {
-        return new Multiline(this.edges.map( edge => edge.shape.transform(matrix)));
-    }
-
-    /**
-     * Transform multiline into array of shapes
-     * @returns {Shape[]}
-     */
-    toShapes() {
-        return this.edges.map(edge => edge.shape.clone())
-    }
-
-    /**
-     * This method returns an object that defines how data will be
-     * serialized when called JSON.stringify() method
-     * @returns {Object}
-     */
-    toJSON() {
-        return this.edges.map(edge => edge.toJSON());
-    }
-
-    /**
-     * Return string to draw multiline in svg
-     * @param attrs  - an object with attributes for svg path element
-     * TODO: support semi-infinite Ray and infinite Line
-     * @returns {string}
-     */
-    svg(attrs = {}) {
-        let svgStr = `\n<path ${convertToString({fill: "none", ...attrs})} d="`;
-        svgStr += `\nM${this.first.start.x},${this.first.start.y}`;
-        for (let edge of this) {
-            svgStr += edge.svg();
-        }
-        svgStr += `" >\n</path>`;
-        return svgStr;
-    }
-}
-
-Flatten.Multiline = Multiline;
-
-/**
- * Shortcut function to create multiline
- * @param args
- */
-const multiline = (...args) => new Flatten.Multiline(...args);
-Flatten.multiline = multiline;
 
 /**
  * @module RayShoot

--- a/dist/main.umd.js
+++ b/dist/main.umd.js
@@ -401,6 +401,271 @@
         }
     }
 
+    const defaultAttributes = {
+        stroke: "black"
+    };
+
+    class SVGAttributes {
+        constructor(args = defaultAttributes) {
+            for(const property in args) {
+                this[property] = args[property];
+            }
+            this.stroke = args.stroke ?? defaultAttributes.stroke;
+        }
+
+        toAttributesString() {
+            return Object.keys(this)
+                .reduce( (acc, key) =>
+                        acc + (this[key] !== undefined ? this.toAttrString(key, this[key]) : "")
+                , ``)
+        }
+
+        toAttrString(key, value) {
+            const SVGKey = key === "className" ? "class" : this.convertCamelToKebabCase(key);
+            return value === null ? `${SVGKey} ` : `${SVGKey}="${value.toString()}" `
+        }
+
+        convertCamelToKebabCase(str) {
+            return str
+                .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
+                .join('-')
+                .toLowerCase();
+        }
+    }
+
+    function convertToString(attrs) {
+        return new SVGAttributes(attrs).toAttributesString()
+    }
+
+    /**
+     * Class Multiline represent connected path of [edges]{@link Flatten.Edge}, where each edge may be
+     * [segment]{@link Flatten.Segment}, [arc]{@link Flatten.Arc}, [line]{@link Flatten.Line} or [ray]{@link Flatten.Ray}
+     */
+    class Multiline extends LinkedList {
+        constructor(...args) {
+            super();
+
+            if (args.length === 0) {
+                return;
+            }
+
+            if (args.length === 1) {
+                if (args[0] instanceof Array) {
+                    let shapes = args[0];
+                    if (shapes.length === 0)
+                        return;
+
+                    // TODO: more strict validation:
+                    // there may be only one line
+                    // only first and last may be rays
+                    shapes.every((shape) => {
+                        return shape instanceof Flatten.Segment ||
+                            shape instanceof Flatten.Arc ||
+                            shape instanceof Flatten.Ray ||
+                            shape instanceof Flatten.Line
+                    });
+
+                    for (let shape of shapes) {
+                        let edge = new Flatten.Edge(shape);
+                        this.append(edge);
+                    }
+
+                    this.setArcLength();
+                }
+            }
+        }
+
+        /**
+         * (Getter) Return array of edges
+         * @returns {Edge[]}
+         */
+        get edges() {
+            return [...this];
+        }
+
+        /**
+         * (Getter) Return bounding box of the multiline
+         * @returns {Box}
+         */
+        get box() {
+            return this.edges.reduce( (acc,edge) => acc.merge(edge.box), new Flatten.Box() );
+        }
+
+        /**
+         * (Getter) Returns array of vertices
+         * @returns {Point[]}
+         */
+        get vertices() {
+            let v = this.edges.map(edge => edge.start);
+            v.push(this.last.end);
+            return v;
+        }
+
+        /**
+         * Return new cloned instance of Multiline
+         * @returns {Multiline}
+         */
+        clone() {
+            return new Multiline(this.toShapes());
+        }
+
+        /**
+         * Set arc_length property for each of the edges in the face.
+         * Arc_length of the edge it the arc length from the first edge of the face
+         */
+        setArcLength() {
+            for (let edge of this) {
+                this.setOneEdgeArcLength(edge);
+            }
+        }
+
+        setOneEdgeArcLength(edge) {
+            if (edge === this.first) {
+                edge.arc_length = 0.0;
+            } else {
+                edge.arc_length = edge.prev.arc_length + edge.prev.length;
+            }
+        }
+
+        /**
+         * Split edge and add new vertex, return new edge inserted
+         * @param {Point} pt - point on edge that will be added as new vertex
+         * @param {Edge} edge - edge to split
+         * @returns {Edge}
+         */
+        addVertex(pt, edge) {
+            let shapes = edge.shape.split(pt);
+            // if (shapes.length < 2) return;
+
+            if (shapes[0] === null)   // point incident to edge start vertex, return previous edge
+               return edge.prev;
+
+            if (shapes[1] === null)   // point incident to edge end vertex, return edge itself
+               return edge;
+
+            let newEdge = new Flatten.Edge(shapes[0]);
+            let edgeBefore = edge.prev;
+
+            /* Insert first split edge into linked list after edgeBefore */
+            this.insert(newEdge, edgeBefore);     // edge.face ?
+
+            // Update edge shape with second split edge keeping links
+            edge.shape = shapes[1];
+
+            return newEdge;
+        }
+
+        getChain(edgeFrom, edgeTo) {
+            let edges = [];
+            for (let edge = edgeFrom; edge !== edgeTo.next; edge = edge.next) {
+                edges.push(edge);
+            }
+            return edges
+        }
+
+        /**
+         * Split edges of multiline with intersection points and return mutated multiline
+         * @param {Point[]} ip - array of points to be added as new vertices
+         * @returns {Multiline}
+         */
+        split(ip) {
+            for (let pt of ip) {
+                let edge = this.findEdgeByPoint(pt);
+                this.addVertex(pt, edge);
+            }
+            return this;
+        }
+
+        /**
+         * Returns edge which contains given point
+         * @param {Point} pt
+         * @returns {Edge}
+         */
+        findEdgeByPoint(pt) {
+            let edgeFound;
+            for (let edge of this) {
+                if (edge.shape.contains(pt)) {
+                    edgeFound = edge;
+                    break;
+                }
+            }
+            return edgeFound;
+        }
+
+        /**
+         * Returns new multiline translated by vector vec
+         * @param {Vector} vec
+         * @returns {Multiline}
+         */
+        translate(vec) {
+            return new Multiline(this.edges.map( edge => edge.shape.translate(vec)));
+        }
+
+        /**
+         * Return new multiline rotated by given angle around given point
+         * If point omitted, rotate around origin (0,0)
+         * Positive value of angle defines rotation counterclockwise, negative - clockwise
+         * @param {number} angle - rotation angle in radians
+         * @param {Point} center - rotation center, default is (0,0)
+         * @returns {Multiline} - new rotated polygon
+         */
+        rotate(angle = 0, center = new Flatten.Point()) {
+            return new Multiline(this.edges.map( edge => edge.shape.rotate(angle, center) ));
+        }
+
+        /**
+         * Return new multiline transformed using affine transformation matrix
+         * Method does not support unbounded shapes
+         * @param {Matrix} matrix - affine transformation matrix
+         * @returns {Multiline} - new multiline
+         */
+        transform(matrix = new Flatten.Matrix()) {
+            return new Multiline(this.edges.map( edge => edge.shape.transform(matrix)));
+        }
+
+        /**
+         * Transform multiline into array of shapes
+         * @returns {Shape[]}
+         */
+        toShapes() {
+            return this.edges.map(edge => edge.shape.clone())
+        }
+
+        /**
+         * This method returns an object that defines how data will be
+         * serialized when called JSON.stringify() method
+         * @returns {Object}
+         */
+        toJSON() {
+            return this.edges.map(edge => edge.toJSON());
+        }
+
+        /**
+         * Return string to draw multiline in svg
+         * @param attrs  - an object with attributes for svg path element
+         * TODO: support semi-infinite Ray and infinite Line
+         * @returns {string}
+         */
+        svg(attrs = {}) {
+            let svgStr = `\n<path ${convertToString({fill: "none", ...attrs})} d="`;
+            svgStr += `\nM${this.first.start.x},${this.first.start.y}`;
+            for (let edge of this) {
+                svgStr += edge.svg();
+            }
+            svgStr += `" >\n</path>`;
+            return svgStr;
+        }
+    }
+
+    Flatten.Multiline = Multiline;
+
+    /**
+     * Shortcut function to create multiline
+     * @param args
+     */
+    const multiline = (...args) => new Flatten.Multiline(...args);
+    Flatten.multiline = multiline;
+
     /*
         Smart intersections describe intersection points that refers to the edges they intersect
         This function are supposed for internal usage by morphing and relation methods between
@@ -456,11 +721,7 @@
 
     function sortIntersections(intersections)
     {
-        // if (intersections.int_points1.length === 0) return;
-
         // augment intersections with new sorted arrays
-        // intersections.int_points1_sorted = intersections.int_points1.slice().sort(compareFn);
-        // intersections.int_points2_sorted = intersections.int_points2.slice().sort(compareFn);
         intersections.int_points1_sorted = getSortedArray(intersections.int_points1);
         intersections.int_points2_sorted = getSortedArray(intersections.int_points2);
     }
@@ -503,18 +764,6 @@
         }
         return 0;
     }
-
-    // export function getSortedArrayOnLine(line, int_points) {
-    //     return int_points.slice().sort( (int_point1, int_point2) => {
-    //         if (line.coord(int_point1.pt) < line.coord(int_point2.pt)) {
-    //             return -1;
-    //         }
-    //         if (line.coord(int_point1.pt) > line.coord(int_point2.pt)) {
-    //             return 1;
-    //         }
-    //         return 0;
-    //     })
-    // }
 
     function filterDuplicatedIntersections(intersections)
     {
@@ -747,14 +996,10 @@
                 int_point.is_vertex |= END_VERTEX$1;
             }
 
-            if (int_point.is_vertex & START_VERTEX$1) {  // nothing to split
+            if (int_point.is_vertex & START_VERTEX$1) {    // nothing to split
+                int_point.edge_before = edge.prev;
                 if (edge.prev) {
-                    int_point.edge_before = edge.prev;           // polygon
-                    int_point.is_vertex = END_VERTEX$1;
-                }
-                else {                                           // multiline start vertex
-                    int_point.edge_after = int_point.edge_before;
-                    int_point.edge_before = edge.prev;
+                    int_point.is_vertex = END_VERTEX$1;   // polygon
                 }
                 continue;
             }
@@ -769,6 +1014,11 @@
         for (let int_point of int_points) {
             if (int_point.edge_before) {
                 int_point.edge_after = int_point.edge_before.next;
+            }
+            else {
+                if (polygon instanceof Multiline && int_point.is_vertex & START_VERTEX$1) {
+                    int_point.edge_after = polygon.first;
+                }
             }
         }
     }
@@ -2304,271 +2554,6 @@
         return intersectLine2Polygon(createLineFromRay(ray), polygon)
             .filter(pt => ray.contains(pt))
     }
-
-    const defaultAttributes = {
-        stroke: "black"
-    };
-
-    class SVGAttributes {
-        constructor(args = defaultAttributes) {
-            for(const property in args) {
-                this[property] = args[property];
-            }
-            this.stroke = args.stroke ?? defaultAttributes.stroke;
-        }
-
-        toAttributesString() {
-            return Object.keys(this)
-                .reduce( (acc, key) =>
-                        acc + (this[key] !== undefined ? this.toAttrString(key, this[key]) : "")
-                , ``)
-        }
-
-        toAttrString(key, value) {
-            const SVGKey = key === "className" ? "class" : this.convertCamelToKebabCase(key);
-            return value === null ? `${SVGKey} ` : `${SVGKey}="${value.toString()}" `
-        }
-
-        convertCamelToKebabCase(str) {
-            return str
-                .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
-                .join('-')
-                .toLowerCase();
-        }
-    }
-
-    function convertToString(attrs) {
-        return new SVGAttributes(attrs).toAttributesString()
-    }
-
-    /**
-     * Class Multiline represent connected path of [edges]{@link Flatten.Edge}, where each edge may be
-     * [segment]{@link Flatten.Segment}, [arc]{@link Flatten.Arc}, [line]{@link Flatten.Line} or [ray]{@link Flatten.Ray}
-     */
-    class Multiline extends LinkedList {
-        constructor(...args) {
-            super();
-
-            if (args.length === 0) {
-                return;
-            }
-
-            if (args.length === 1) {
-                if (args[0] instanceof Array) {
-                    let shapes = args[0];
-                    if (shapes.length === 0)
-                        return;
-
-                    // TODO: more strict validation:
-                    // there may be only one line
-                    // only first and last may be rays
-                    shapes.every((shape) => {
-                        return shape instanceof Flatten.Segment ||
-                            shape instanceof Flatten.Arc ||
-                            shape instanceof Flatten.Ray ||
-                            shape instanceof Flatten.Line
-                    });
-
-                    for (let shape of shapes) {
-                        let edge = new Flatten.Edge(shape);
-                        this.append(edge);
-                    }
-
-                    this.setArcLength();
-                }
-            }
-        }
-
-        /**
-         * (Getter) Return array of edges
-         * @returns {Edge[]}
-         */
-        get edges() {
-            return [...this];
-        }
-
-        /**
-         * (Getter) Return bounding box of the multiline
-         * @returns {Box}
-         */
-        get box() {
-            return this.edges.reduce( (acc,edge) => acc.merge(edge.box), new Flatten.Box() );
-        }
-
-        /**
-         * (Getter) Returns array of vertices
-         * @returns {Point[]}
-         */
-        get vertices() {
-            let v = this.edges.map(edge => edge.start);
-            v.push(this.last.end);
-            return v;
-        }
-
-        /**
-         * Return new cloned instance of Multiline
-         * @returns {Multiline}
-         */
-        clone() {
-            return new Multiline(this.toShapes());
-        }
-
-        /**
-         * Set arc_length property for each of the edges in the face.
-         * Arc_length of the edge it the arc length from the first edge of the face
-         */
-        setArcLength() {
-            for (let edge of this) {
-                this.setOneEdgeArcLength(edge);
-            }
-        }
-
-        setOneEdgeArcLength(edge) {
-            if (edge === this.first) {
-                edge.arc_length = 0.0;
-            } else {
-                edge.arc_length = edge.prev.arc_length + edge.prev.length;
-            }
-        }
-
-        /**
-         * Split edge and add new vertex, return new edge inserted
-         * @param {Point} pt - point on edge that will be added as new vertex
-         * @param {Edge} edge - edge to split
-         * @returns {Edge}
-         */
-        addVertex(pt, edge) {
-            let shapes = edge.shape.split(pt);
-            // if (shapes.length < 2) return;
-
-            if (shapes[0] === null)   // point incident to edge start vertex, return previous edge
-               return edge.prev;
-
-            if (shapes[1] === null)   // point incident to edge end vertex, return edge itself
-               return edge;
-
-            let newEdge = new Flatten.Edge(shapes[0]);
-            let edgeBefore = edge.prev;
-
-            /* Insert first split edge into linked list after edgeBefore */
-            this.insert(newEdge, edgeBefore);     // edge.face ?
-
-            // Update edge shape with second split edge keeping links
-            edge.shape = shapes[1];
-
-            return newEdge;
-        }
-
-        getChain(edgeFrom, edgeTo) {
-            let edges = [];
-            for (let edge = edgeFrom; edge !== edgeTo.next; edge = edge.next) {
-                edges.push(edge);
-            }
-            return edges
-        }
-
-        /**
-         * Split edges of multiline with intersection points and return mutated multiline
-         * @param {Point[]} ip - array of points to be added as new vertices
-         * @returns {Multiline}
-         */
-        split(ip) {
-            for (let pt of ip) {
-                let edge = this.findEdgeByPoint(pt);
-                this.addVertex(pt, edge);
-            }
-            return this;
-        }
-
-        /**
-         * Returns edge which contains given point
-         * @param {Point} pt
-         * @returns {Edge}
-         */
-        findEdgeByPoint(pt) {
-            let edgeFound;
-            for (let edge of this) {
-                if (edge.shape.contains(pt)) {
-                    edgeFound = edge;
-                    break;
-                }
-            }
-            return edgeFound;
-        }
-
-        /**
-         * Returns new multiline translated by vector vec
-         * @param {Vector} vec
-         * @returns {Multiline}
-         */
-        translate(vec) {
-            return new Multiline(this.edges.map( edge => edge.shape.translate(vec)));
-        }
-
-        /**
-         * Return new multiline rotated by given angle around given point
-         * If point omitted, rotate around origin (0,0)
-         * Positive value of angle defines rotation counterclockwise, negative - clockwise
-         * @param {number} angle - rotation angle in radians
-         * @param {Point} center - rotation center, default is (0,0)
-         * @returns {Multiline} - new rotated polygon
-         */
-        rotate(angle = 0, center = new Flatten.Point()) {
-            return new Multiline(this.edges.map( edge => edge.shape.rotate(angle, center) ));
-        }
-
-        /**
-         * Return new multiline transformed using affine transformation matrix
-         * Method does not support unbounded shapes
-         * @param {Matrix} matrix - affine transformation matrix
-         * @returns {Multiline} - new multiline
-         */
-        transform(matrix = new Flatten.Matrix()) {
-            return new Multiline(this.edges.map( edge => edge.shape.transform(matrix)));
-        }
-
-        /**
-         * Transform multiline into array of shapes
-         * @returns {Shape[]}
-         */
-        toShapes() {
-            return this.edges.map(edge => edge.shape.clone())
-        }
-
-        /**
-         * This method returns an object that defines how data will be
-         * serialized when called JSON.stringify() method
-         * @returns {Object}
-         */
-        toJSON() {
-            return this.edges.map(edge => edge.toJSON());
-        }
-
-        /**
-         * Return string to draw multiline in svg
-         * @param attrs  - an object with attributes for svg path element
-         * TODO: support semi-infinite Ray and infinite Line
-         * @returns {string}
-         */
-        svg(attrs = {}) {
-            let svgStr = `\n<path ${convertToString({fill: "none", ...attrs})} d="`;
-            svgStr += `\nM${this.first.start.x},${this.first.start.y}`;
-            for (let edge of this) {
-                svgStr += edge.svg();
-            }
-            svgStr += `" >\n</path>`;
-            return svgStr;
-        }
-    }
-
-    Flatten.Multiline = Multiline;
-
-    /**
-     * Shortcut function to create multiline
-     * @param args
-     */
-    const multiline = (...args) => new Flatten.Multiline(...args);
-    Flatten.multiline = multiline;
 
     /**
      * @module RayShoot

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatten-js/core",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Javascript library for 2d geometry",
   "main": "dist/main.cjs",
   "umd:main": "dist/main.umd.js",

--- a/src/data_structures/smart_intersections.js
+++ b/src/data_structures/smart_intersections.js
@@ -4,6 +4,7 @@
  */
 import * as Utils from "../utils/utils";
 import * as Constants from '../utils/constants';
+import {Multiline} from "../classes/multiline";
 
 export function addToIntPoints(edge, pt, int_points)
 {
@@ -55,11 +56,7 @@ export function addToIntPoints(edge, pt, int_points)
 
 export function sortIntersections(intersections)
 {
-    // if (intersections.int_points1.length === 0) return;
-
     // augment intersections with new sorted arrays
-    // intersections.int_points1_sorted = intersections.int_points1.slice().sort(compareFn);
-    // intersections.int_points2_sorted = intersections.int_points2.slice().sort(compareFn);
     intersections.int_points1_sorted = getSortedArray(intersections.int_points1);
     intersections.int_points2_sorted = getSortedArray(intersections.int_points2);
 }
@@ -102,18 +99,6 @@ function compareFn(ip1, ip2)
     }
     return 0;
 }
-
-// export function getSortedArrayOnLine(line, int_points) {
-//     return int_points.slice().sort( (int_point1, int_point2) => {
-//         if (line.coord(int_point1.pt) < line.coord(int_point2.pt)) {
-//             return -1;
-//         }
-//         if (line.coord(int_point1.pt) > line.coord(int_point2.pt)) {
-//             return 1;
-//         }
-//         return 0;
-//     })
-// }
 
 export function filterDuplicatedIntersections(intersections)
 {
@@ -346,14 +331,10 @@ export function splitByIntersections(polygon, int_points)
             int_point.is_vertex |= Constants.END_VERTEX;
         }
 
-        if (int_point.is_vertex & Constants.START_VERTEX) {  // nothing to split
+        if (int_point.is_vertex & Constants.START_VERTEX) {    // nothing to split
+            int_point.edge_before = edge.prev;
             if (edge.prev) {
-                int_point.edge_before = edge.prev;           // polygon
-                int_point.is_vertex = Constants.END_VERTEX;
-            }
-            else {                                           // multiline start vertex
-                int_point.edge_after = int_point.edge_before
-                int_point.edge_before = edge.prev
+                int_point.is_vertex = Constants.END_VERTEX;   // polygon
             }
             continue;
         }
@@ -368,6 +349,11 @@ export function splitByIntersections(polygon, int_points)
     for (let int_point of int_points) {
         if (int_point.edge_before) {
             int_point.edge_after = int_point.edge_before.next;
+        }
+        else {
+            if (polygon instanceof Multiline && int_point.is_vertex & Constants.START_VERTEX) {
+                int_point.edge_after = polygon.first
+            }
         }
     }
 }

--- a/test/classes/polygon.js
+++ b/test/classes/polygon.js
@@ -933,6 +933,54 @@ describe('#Flatten.Polygon', function() {
         expect(newPoly.faces.size).to.equal(2);
         expect(newPoly.edges.size).to.equal(10)
     })
+    it('Polygon.cut error #175', () => {
+        // Create polygon from json
+        let json = [
+            [
+                {
+                    ps: {x: 641.64, y: 118.32, name: "point"},
+                    pe: {x: 641.64, y: 151.74, name: "point"},
+                    name: "segment"
+                },
+                {
+                    ps: {x: 641.64, y: 151.74, name: "point"},
+                    pe: {x: 504.66, y: 151.74, name: "point"},
+                    name: "segment"
+                },
+                {
+                    ps: {x: 504.66, y: 151.74, name: "point"},
+                    pe: {x: 504.66, y: 118.32, name: "point"},
+                    name: "segment"
+                },
+                {
+                    ps: {x: 504.66, y: 118.32, name: "point"},
+                    pe: {x: 641.64, y: 118.32, name: "point"},
+                    name: "segment"
+                }
+            ]
+        ];
+
+        let polygon = new Polygon(json);
+
+        // Create Multiline
+        let mlj = [
+            {
+                ps: {x: 576.48, y: 118.32, name: "point"},
+                pe: {x: 576.48, y: 274.14, name: "point"},
+                name: "segment"
+            },
+            {
+                ps: {x: 576.48, y: 274.14, name: "point"},
+                pe: {x: 641.64, y: 274.14, name: "point"},
+                name: "segment"
+            }
+        ];
+        let ml = multiline(mlj.map((s) => segment(s)));
+        const newPoly = polygon.cut(ml)
+        const a = newPoly.toArray()
+        expect(newPoly.faces.size).to.equal(2);
+        expect(newPoly.edges.size).to.equal(8)
+    })
     describe('#Intersections', function () {
         it('Can perform intersection between polygons', function () {
             const poly1 = new Polygon(


### PR DESCRIPTION
Fix polygon.cut error: issue #175.
In splitByIntersections, when int_point is a start point, set int_point.after to the first edge of a multiline