### PR TITLE
Fix intersecting a multiline with a multiline

### DIFF
--- a/src/algorithms/intersection.js
+++ b/src/algorithms/intersection.js
@@ -655,7 +655,7 @@ export function intersectMultiline2Multiline(multiline1, multiline2) {
     let ip = [];
     for (let edge1 of multiline1) {
         for (let edge2 of multiline2) {
-            ip = [...ip, ...intersectShape2Shape(edge1, edge2)];
+            ip = [...ip, ...intersectShape2Shape(edge1.shape, edge2.shape)];
         }
     }
     return ip;


### PR DESCRIPTION
Fix a bug where the edge was passed to the intersection function instead of the underlying shape.