### PR TITLE
Fix Polygon.cut return type in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -538,7 +538,7 @@ declare namespace Flatten {
         removeChain(face: Face, edgeFrom: PolygonEdge, edgeTo: PolygonEdge): void;
         addVertex(pt: Point, edge: PolygonEdge): PolygonEdge;
         removeEndVertex(edge: Edge): void;
-        cut(multiline: Multiline): Polygon[];
+        cut(multiline: Multiline): Polygon;
         cutWithLine(line: Line): Polygon;
         findEdgeByPoint(pt: Point): PolygonEdge;
         splitToIslands() : Polygon[];


### PR DESCRIPTION
The correct type is `Polygon` which you can see in the tests in test/classes/polygon.js. 

It looks like the return type was changed from `Polygon[]` to `Polygon` here b15e05d70c4ccd1db26e6007c945f16de674c3e3 but never updated in the type definitions. 

The workaround I'm using to deal with this (in my typescript project with flatten-js/core v1.6.2) is `polygon.cut(multiline) as unknown as Flatten.Polygon`