### PR TITLE
Fix box contains method for arcs + add tests

### DIFF
--- a/src/classes/box.js
+++ b/src/classes/box.js
@@ -269,7 +269,7 @@ export class Box extends Shape {
 
         if (shape instanceof Flatten.Arc) {
             return shape.vertices.every(vertex => this.contains(vertex)) &&
-                shape.toSegments().every(segment => intersectSegment2Arc(segment, shape).length === 0)
+                this.toSegments().every(segment => intersectSegment2Arc(segment, shape).length === 0)
         }
 
         if (shape instanceof Flatten.Line || shape instanceof Flatten.Ray) {

--- a/test/classes/box.js
+++ b/test/classes/box.js
@@ -4,7 +4,7 @@
 'use strict';
 
 import { expect } from 'chai';
-import Flatten from '../../index';
+import Flatten, {Arc} from '../../index';
 
 import {Box, Point} from '../../index';
 
@@ -22,6 +22,26 @@ describe('#Flatten.Box', function() {
         let box1 = new Box(1, 1, 3, 3);
         let box2 = new Box(-3, -3, 2, 2);
         expect(box1.merge(box2)).to.deep.equal({xmin:-3, ymin:-3, xmax:3, ymax:3});
+    });
+    it('Method contains correctly marks arc as contained in box', function () {
+        let box = new Box(0, 0, 10, 10);
+        let arc = new Arc(new Point(1, 1), 1, 0, Math.PI / 4, true);
+        expect(box.contains(arc)).to.equal(true);
+    });
+    it('Method contains correctly marks arc as not contained in box (fully outside)', function () {
+        let box = new Box(0, 0, 10, 10);
+        let arc = new Arc(new Point(20, 20), 1, 0, Math.PI / 4, false);
+        expect(box.contains(arc)).to.equal(false);
+    });
+    it('Method contains correctly marks arc as not contained in box (middle of arc partly outside)', function () {
+        let box = new Box(0, 0, 10, 10);
+        let arc = new Arc(new Point(1, 1), 10, 0, Math.PI / 4, false);
+        expect(box.contains(arc)).to.equal(false);
+    });
+    it('Method contains correctly marks arc as not contained in box (endpoint of arc outside)', function () {
+        let box = new Box(0, 0, 10, 10);
+        let arc = new Arc(new Point(11, 11), 5, Math.PI, Math.PI / 2 * 3, false);
+        expect(box.contains(arc)).to.equal(false);
     });
     it('Method svg() without parameters creates svg string with default attributes', function() {
         let box = new Box(-30, -30, 20, 20);


### PR DESCRIPTION
I noticed this error when i try to use the box.contains(arc) method.
```
TypeError: shape.toSegments is not a function
      at Box.contains (src\classes\/box.js:272:23)
```

I wrote some tests and it does seem to fail the test:
```
  #Flatten.Box
    √ May create new instance of Box
    √ Method intersect returns true if two boxes intersected      
    √ Method expand expands current box with other
    1) Method contains correctly marks arc as contained in box
    √ Method contains correctly marks arc as not contained in box (fully outside)
    √ Method contains correctly marks arc as not contained in box (middle of arc partly outside)
    √ Method contains correctly marks arc as not contained in box (endpoint of arc outside)
    √ Method svg() without parameters creates svg string with default attributes
    √ Method svg() with extra parameters may add additional attributes
    √ Can measure distance to box



  1) #Flatten.Box
       Method contains correctly marks arc as contained in box:   
     TypeError: shape.toSegments is not a function
      at Box.contains (src\classes\/box.js:272:23)
      at Context.<anonymous> (test\classes\/box.js:29:20)
      at processImmediate (node:internal/timers:491:21)
```

I also fixed the bug: The box should be split into segments and checked against the arc. Currently the arc was being split into segments and that method doesn't exist on the arc class
```javascript
        if (shape instanceof Flatten.Arc) {
            return shape.vertices.every(vertex => this.contains(vertex)) &&
                this.toSegments().every(segment => intersectSegment2Arc(segment, shape).length === 0)
        }
```
