### PR TITLE
Fix accidental Number wrapper type in Arc definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,7 +118,7 @@ declare namespace Flatten {
 
         // members
         ps: Point;
-        r: Number;
+        r: number;
         startAngle: number;
         endAngle: number;
 


### PR DESCRIPTION
The Number (wrapper type, not the primitive) typo makes Typescript complain with using it for math. This fixes the issue.