### PR TITLE
Add dpath() to Multiline

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -586,6 +586,7 @@ declare namespace Flatten {
         toShapes(): MultilineShapes;
         toJSON() : Object;
         svg(attrs?: SVGAttributes): string;
+        dpath(): string;
     }
 
     class Inversion {


### PR DESCRIPTION
It might be missing on other classes as well, but this is the specific issue I bumped into.