### PR TITLE
Fix wrong type of split argument for Ray

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -309,7 +309,7 @@ declare namespace Flatten {
         // public methods
         clone(): Ray;
         contains(pt: Point): boolean;
-        split(pt: Point[]): AnyShape[];
+        split(pt: Point): AnyShape[];
         intersect(shape: AnyShape): Point[];
         translate(vec: Vector): Ray;
         translate(x:number, y:number): Ray;


### PR DESCRIPTION
See https://github.com/alexbol99/flatten-js/blob/master/src/classes/ray.js#L132 — it definitely takes a single point rather than an array (unlike `Line`).