### PR TITLE
Changed Arc.breakToFunctional to work with only angles and use exact …

### DIFF
--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -6192,55 +6192,81 @@ class Arc extends Shape {
      */
     breakToFunctional() {
         let func_arcs_array = [];
-        let angles = [0, Math.PI / 2, 2 * Math.PI / 2, 3 * Math.PI / 2];
-        let pts = [
-            this.pc.translate(this.r, 0),
-            this.pc.translate(0, this.r),
-            this.pc.translate(-this.r, 0),
-            this.pc.translate(0, -this.r)
-        ];
+        let angles = [0, Math.PI / 2, Math.PI, 3 * Math.PI / 2];
+        let startAngle = this.startAngle;
+        let endAngle = this.endAngle;
+        let sweep;
 
-        // If arc contains extreme point,
-        // create test arc started at start point and ended at this extreme point
-        let test_arcs = [];
-        for (let i = 0; i < 4; i++) {
-            if (pts[i].on(this)) {
-                test_arcs.push(new Flatten.Arc(this.pc, this.r, this.startAngle, angles[i], this.counterClockwise));
+        // check full circle before normalizing angles
+        if (Flatten.Utils.EQ(Math.abs(startAngle - endAngle), Flatten.PIx2)) {
+            sweep = Flatten.PIx2;
+            endAngle = startAngle;
+        }
+
+        // normalize angles
+        if (Math.abs(startAngle) > Flatten.PIx2) {
+            startAngle -= Math.trunc(startAngle / Flatten.PIx2) * Flatten.PIx2;
+        }
+        if (startAngle < 0) {
+            startAngle += Flatten.PIx2;
+        }
+        if (Math.abs(endAngle) > Flatten.PIx2) {
+            endAngle -= Math.trunc(endAngle / Flatten.PIx2) * Flatten.PIx2;
+        }
+        if (endAngle < 0) {
+            endAngle += Flatten.PIx2;
+        }
+
+        // calculate sweep if it isn't a full circle
+        if (sweep === undefined) {
+            sweep = this.counterClockwise ? endAngle - startAngle : startAngle - endAngle;
+            if (sweep < 0) {
+                sweep += Flatten.PIx2;
             }
         }
 
-        if (test_arcs.length === 0) {                  // arc does contain any extreme point
-            func_arcs_array.push(this.clone());
-        } else {                                        // arc passes extreme point
-            // sort these arcs by length
-            test_arcs.sort((arc1, arc2) => arc1.length - arc2.length);
-
-            for (let i = 0; i < test_arcs.length; i++) {
-                let prev_arc = func_arcs_array.length > 0 ? func_arcs_array[func_arcs_array.length - 1] : undefined;
-                let new_arc;
-                if (prev_arc) {
-                    new_arc = new Flatten.Arc(this.pc, this.r, prev_arc.endAngle, test_arcs[i].endAngle, this.counterClockwise);
-                } else {
-                    new_arc = new Flatten.Arc(this.pc, this.r, this.startAngle, test_arcs[i].endAngle, this.counterClockwise);
-                }
-                if (!Flatten.Utils.EQ_0(new_arc.length)) {
-                    func_arcs_array.push(new_arc.clone());
-                }
-            }
-
-            // add last sub arc
-            let prev_arc = func_arcs_array.length > 0 ? func_arcs_array[func_arcs_array.length - 1] : undefined;
-            let new_arc;
-            if (prev_arc) {
-                new_arc = new Flatten.Arc(this.pc, this.r, prev_arc.endAngle, this.endAngle, this.counterClockwise);
-            } else {
-                new_arc = new Flatten.Arc(this.pc, this.r, this.startAngle, this.endAngle, this.counterClockwise);
-            }
-            // It could be 2*PI when occasionally start = 0 and end = 2*PI but this is not valid for breakToFunctional
-            if (!Flatten.Utils.EQ_0(new_arc.length) && !Flatten.Utils.EQ(new_arc.sweep, 2*Math.PI)) {
-                func_arcs_array.push(new_arc.clone());
-            }
+        // set up the loop
+        let prev = startAngle;
+        let next;
+        let firstj;
+        let d;
+        if (this.counterClockwise) {
+            firstj = Math.ceil(startAngle / (Math.PI / 2)) % 4;
+            d = 1;
+        } else {
+            firstj = Math.floor(startAngle / (Math.PI / 2)) % 4;
+            d = -1;
         }
+
+        // loop over crossings while incremental sweep is less than sweep
+        for (let i = 0, j = firstj; i < 4; i++, j = (j + d + 4) % 4) {
+            next = angles[j];
+            if (next === prev) {
+                continue;
+            }
+            let incrementalSweep = this.counterClockwise ? next - startAngle : startAngle - next;
+            if (incrementalSweep < 0) {
+                incrementalSweep += Flatten.PIx2;
+            }
+            if (incrementalSweep > sweep) {
+                break;
+            }
+            func_arcs_array.push(new Flatten.Arc(this.pc, this.r, prev, next, this.counterClockwise));
+            prev = next;
+        }
+
+        // return the original arc for no crossings
+        if (func_arcs_array.length === 0) {
+            func_arcs_array.push(this);
+            return func_arcs_array;
+        }
+
+        // add the last arc
+        next = endAngle;
+        if (prev !== next) {
+            func_arcs_array.push(new Flatten.Arc(this.pc, this.r, prev, next, this.counterClockwise));
+        }
+
         return func_arcs_array;
     }
 

--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -6188,55 +6188,81 @@ class Arc extends Shape {
      */
     breakToFunctional() {
         let func_arcs_array = [];
-        let angles = [0, Math.PI / 2, 2 * Math.PI / 2, 3 * Math.PI / 2];
-        let pts = [
-            this.pc.translate(this.r, 0),
-            this.pc.translate(0, this.r),
-            this.pc.translate(-this.r, 0),
-            this.pc.translate(0, -this.r)
-        ];
+        let angles = [0, Math.PI / 2, Math.PI, 3 * Math.PI / 2];
+        let startAngle = this.startAngle;
+        let endAngle = this.endAngle;
+        let sweep;
 
-        // If arc contains extreme point,
-        // create test arc started at start point and ended at this extreme point
-        let test_arcs = [];
-        for (let i = 0; i < 4; i++) {
-            if (pts[i].on(this)) {
-                test_arcs.push(new Flatten.Arc(this.pc, this.r, this.startAngle, angles[i], this.counterClockwise));
+        // check full circle before normalizing angles
+        if (Flatten.Utils.EQ(Math.abs(startAngle - endAngle), Flatten.PIx2)) {
+            sweep = Flatten.PIx2;
+            endAngle = startAngle;
+        }
+
+        // normalize angles
+        if (Math.abs(startAngle) > Flatten.PIx2) {
+            startAngle -= Math.trunc(startAngle / Flatten.PIx2) * Flatten.PIx2;
+        }
+        if (startAngle < 0) {
+            startAngle += Flatten.PIx2;
+        }
+        if (Math.abs(endAngle) > Flatten.PIx2) {
+            endAngle -= Math.trunc(endAngle / Flatten.PIx2) * Flatten.PIx2;
+        }
+        if (endAngle < 0) {
+            endAngle += Flatten.PIx2;
+        }
+
+        // calculate sweep if it isn't a full circle
+        if (sweep === undefined) {
+            sweep = this.counterClockwise ? endAngle - startAngle : startAngle - endAngle;
+            if (sweep < 0) {
+                sweep += Flatten.PIx2;
             }
         }
 
-        if (test_arcs.length === 0) {                  // arc does contain any extreme point
-            func_arcs_array.push(this.clone());
-        } else {                                        // arc passes extreme point
-            // sort these arcs by length
-            test_arcs.sort((arc1, arc2) => arc1.length - arc2.length);
-
-            for (let i = 0; i < test_arcs.length; i++) {
-                let prev_arc = func_arcs_array.length > 0 ? func_arcs_array[func_arcs_array.length - 1] : undefined;
-                let new_arc;
-                if (prev_arc) {
-                    new_arc = new Flatten.Arc(this.pc, this.r, prev_arc.endAngle, test_arcs[i].endAngle, this.counterClockwise);
-                } else {
-                    new_arc = new Flatten.Arc(this.pc, this.r, this.startAngle, test_arcs[i].endAngle, this.counterClockwise);
-                }
-                if (!Flatten.Utils.EQ_0(new_arc.length)) {
-                    func_arcs_array.push(new_arc.clone());
-                }
-            }
-
-            // add last sub arc
-            let prev_arc = func_arcs_array.length > 0 ? func_arcs_array[func_arcs_array.length - 1] : undefined;
-            let new_arc;
-            if (prev_arc) {
-                new_arc = new Flatten.Arc(this.pc, this.r, prev_arc.endAngle, this.endAngle, this.counterClockwise);
-            } else {
-                new_arc = new Flatten.Arc(this.pc, this.r, this.startAngle, this.endAngle, this.counterClockwise);
-            }
-            // It could be 2*PI when occasionally start = 0 and end = 2*PI but this is not valid for breakToFunctional
-            if (!Flatten.Utils.EQ_0(new_arc.length) && !Flatten.Utils.EQ(new_arc.sweep, 2*Math.PI)) {
-                func_arcs_array.push(new_arc.clone());
-            }
+        // set up the loop
+        let prev = startAngle;
+        let next;
+        let firstj;
+        let d;
+        if (this.counterClockwise) {
+            firstj = Math.ceil(startAngle / (Math.PI / 2)) % 4;
+            d = 1;
+        } else {
+            firstj = Math.floor(startAngle / (Math.PI / 2)) % 4;
+            d = -1;
         }
+
+        // loop over crossings while incremental sweep is less than sweep
+        for (let i = 0, j = firstj; i < 4; i++, j = (j + d + 4) % 4) {
+            next = angles[j];
+            if (next === prev) {
+                continue;
+            }
+            let incrementalSweep = this.counterClockwise ? next - startAngle : startAngle - next;
+            if (incrementalSweep < 0) {
+                incrementalSweep += Flatten.PIx2;
+            }
+            if (incrementalSweep > sweep) {
+                break;
+            }
+            func_arcs_array.push(new Flatten.Arc(this.pc, this.r, prev, next, this.counterClockwise));
+            prev = next;
+        }
+
+        // return the original arc for no crossings
+        if (func_arcs_array.length === 0) {
+            func_arcs_array.push(this);
+            return func_arcs_array;
+        }
+
+        // add the last arc
+        next = endAngle;
+        if (prev !== next) {
+            func_arcs_array.push(new Flatten.Arc(this.pc, this.r, prev, next, this.counterClockwise));
+        }
+
         return func_arcs_array;
     }
 

--- a/dist/main.umd.js
+++ b/dist/main.umd.js
@@ -6194,55 +6194,81 @@
          */
         breakToFunctional() {
             let func_arcs_array = [];
-            let angles = [0, Math.PI / 2, 2 * Math.PI / 2, 3 * Math.PI / 2];
-            let pts = [
-                this.pc.translate(this.r, 0),
-                this.pc.translate(0, this.r),
-                this.pc.translate(-this.r, 0),
-                this.pc.translate(0, -this.r)
-            ];
+            let angles = [0, Math.PI / 2, Math.PI, 3 * Math.PI / 2];
+            let startAngle = this.startAngle;
+            let endAngle = this.endAngle;
+            let sweep;
 
-            // If arc contains extreme point,
-            // create test arc started at start point and ended at this extreme point
-            let test_arcs = [];
-            for (let i = 0; i < 4; i++) {
-                if (pts[i].on(this)) {
-                    test_arcs.push(new Flatten.Arc(this.pc, this.r, this.startAngle, angles[i], this.counterClockwise));
+            // check full circle before normalizing angles
+            if (Flatten.Utils.EQ(Math.abs(startAngle - endAngle), Flatten.PIx2)) {
+                sweep = Flatten.PIx2;
+                endAngle = startAngle;
+            }
+
+            // normalize angles
+            if (Math.abs(startAngle) > Flatten.PIx2) {
+                startAngle -= Math.trunc(startAngle / Flatten.PIx2) * Flatten.PIx2;
+            }
+            if (startAngle < 0) {
+                startAngle += Flatten.PIx2;
+            }
+            if (Math.abs(endAngle) > Flatten.PIx2) {
+                endAngle -= Math.trunc(endAngle / Flatten.PIx2) * Flatten.PIx2;
+            }
+            if (endAngle < 0) {
+                endAngle += Flatten.PIx2;
+            }
+
+            // calculate sweep if it isn't a full circle
+            if (sweep === undefined) {
+                sweep = this.counterClockwise ? endAngle - startAngle : startAngle - endAngle;
+                if (sweep < 0) {
+                    sweep += Flatten.PIx2;
                 }
             }
 
-            if (test_arcs.length === 0) {                  // arc does contain any extreme point
-                func_arcs_array.push(this.clone());
-            } else {                                        // arc passes extreme point
-                // sort these arcs by length
-                test_arcs.sort((arc1, arc2) => arc1.length - arc2.length);
-
-                for (let i = 0; i < test_arcs.length; i++) {
-                    let prev_arc = func_arcs_array.length > 0 ? func_arcs_array[func_arcs_array.length - 1] : undefined;
-                    let new_arc;
-                    if (prev_arc) {
-                        new_arc = new Flatten.Arc(this.pc, this.r, prev_arc.endAngle, test_arcs[i].endAngle, this.counterClockwise);
-                    } else {
-                        new_arc = new Flatten.Arc(this.pc, this.r, this.startAngle, test_arcs[i].endAngle, this.counterClockwise);
-                    }
-                    if (!Flatten.Utils.EQ_0(new_arc.length)) {
-                        func_arcs_array.push(new_arc.clone());
-                    }
-                }
-
-                // add last sub arc
-                let prev_arc = func_arcs_array.length > 0 ? func_arcs_array[func_arcs_array.length - 1] : undefined;
-                let new_arc;
-                if (prev_arc) {
-                    new_arc = new Flatten.Arc(this.pc, this.r, prev_arc.endAngle, this.endAngle, this.counterClockwise);
-                } else {
-                    new_arc = new Flatten.Arc(this.pc, this.r, this.startAngle, this.endAngle, this.counterClockwise);
-                }
-                // It could be 2*PI when occasionally start = 0 and end = 2*PI but this is not valid for breakToFunctional
-                if (!Flatten.Utils.EQ_0(new_arc.length) && !Flatten.Utils.EQ(new_arc.sweep, 2*Math.PI)) {
-                    func_arcs_array.push(new_arc.clone());
-                }
+            // set up the loop
+            let prev = startAngle;
+            let next;
+            let firstj;
+            let d;
+            if (this.counterClockwise) {
+                firstj = Math.ceil(startAngle / (Math.PI / 2)) % 4;
+                d = 1;
+            } else {
+                firstj = Math.floor(startAngle / (Math.PI / 2)) % 4;
+                d = -1;
             }
+
+            // loop over crossings while incremental sweep is less than sweep
+            for (let i = 0, j = firstj; i < 4; i++, j = (j + d + 4) % 4) {
+                next = angles[j];
+                if (next === prev) {
+                    continue;
+                }
+                let incrementalSweep = this.counterClockwise ? next - startAngle : startAngle - next;
+                if (incrementalSweep < 0) {
+                    incrementalSweep += Flatten.PIx2;
+                }
+                if (incrementalSweep > sweep) {
+                    break;
+                }
+                func_arcs_array.push(new Flatten.Arc(this.pc, this.r, prev, next, this.counterClockwise));
+                prev = next;
+            }
+
+            // return the original arc for no crossings
+            if (func_arcs_array.length === 0) {
+                func_arcs_array.push(this);
+                return func_arcs_array;
+            }
+
+            // add the last arc
+            next = endAngle;
+            if (prev !== next) {
+                func_arcs_array.push(new Flatten.Arc(this.pc, this.r, prev, next, this.counterClockwise));
+            }
+
             return func_arcs_array;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flatten-js/core",
-  "version": "1.5.8",
+  "version": "1.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flatten-js/core",
-      "version": "1.5.8",
+      "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.1.3"

--- a/src/classes/arc.js
+++ b/src/classes/arc.js
@@ -422,7 +422,7 @@ export class Arc extends Shape {
     }
 
     /**
-     * Returns new arc with swapped start and end angles asweepnd reversed direction
+     * Returns new arc with swapped start and end angles and reversed direction
      * @returns {Arc}
      */
     reverse() {

--- a/src/classes/arc.js
+++ b/src/classes/arc.js
@@ -322,55 +322,81 @@ export class Arc extends Shape {
      */
     breakToFunctional() {
         let func_arcs_array = [];
-        let angles = [0, Math.PI / 2, 2 * Math.PI / 2, 3 * Math.PI / 2];
-        let pts = [
-            this.pc.translate(this.r, 0),
-            this.pc.translate(0, this.r),
-            this.pc.translate(-this.r, 0),
-            this.pc.translate(0, -this.r)
-        ];
+        let angles = [0, Math.PI / 2, Math.PI, 3 * Math.PI / 2];
+        let startAngle = this.startAngle;
+        let endAngle = this.endAngle;
+        let sweep;
 
-        // If arc contains extreme point,
-        // create test arc started at start point and ended at this extreme point
-        let test_arcs = [];
-        for (let i = 0; i < 4; i++) {
-            if (pts[i].on(this)) {
-                test_arcs.push(new Flatten.Arc(this.pc, this.r, this.startAngle, angles[i], this.counterClockwise));
+        // check full circle before normalizing angles
+        if (Flatten.Utils.EQ(Math.abs(startAngle - endAngle), Flatten.PIx2)) {
+            sweep = Flatten.PIx2;
+            endAngle = startAngle;
+        }
+
+        // normalize angles
+        if (Math.abs(startAngle) > Flatten.PIx2) {
+            startAngle -= Math.trunc(startAngle / Flatten.PIx2) * Flatten.PIx2;
+        }
+        if (startAngle < 0) {
+            startAngle += Flatten.PIx2;
+        }
+        if (Math.abs(endAngle) > Flatten.PIx2) {
+            endAngle -= Math.trunc(endAngle / Flatten.PIx2) * Flatten.PIx2;
+        }
+        if (endAngle < 0) {
+            endAngle += Flatten.PIx2;
+        }
+
+        // calculate sweep if it isn't a full circle
+        if (sweep === undefined) {
+            sweep = this.counterClockwise ? endAngle - startAngle : startAngle - endAngle;
+            if (sweep < 0) {
+                sweep += Flatten.PIx2;
             }
         }
 
-        if (test_arcs.length === 0) {                  // arc does contain any extreme point
-            func_arcs_array.push(this.clone());
-        } else {                                        // arc passes extreme point
-            // sort these arcs by length
-            test_arcs.sort((arc1, arc2) => arc1.length - arc2.length);
-
-            for (let i = 0; i < test_arcs.length; i++) {
-                let prev_arc = func_arcs_array.length > 0 ? func_arcs_array[func_arcs_array.length - 1] : undefined;
-                let new_arc;
-                if (prev_arc) {
-                    new_arc = new Flatten.Arc(this.pc, this.r, prev_arc.endAngle, test_arcs[i].endAngle, this.counterClockwise);
-                } else {
-                    new_arc = new Flatten.Arc(this.pc, this.r, this.startAngle, test_arcs[i].endAngle, this.counterClockwise);
-                }
-                if (!Flatten.Utils.EQ_0(new_arc.length)) {
-                    func_arcs_array.push(new_arc.clone());
-                }
-            }
-
-            // add last sub arc
-            let prev_arc = func_arcs_array.length > 0 ? func_arcs_array[func_arcs_array.length - 1] : undefined;
-            let new_arc;
-            if (prev_arc) {
-                new_arc = new Flatten.Arc(this.pc, this.r, prev_arc.endAngle, this.endAngle, this.counterClockwise);
-            } else {
-                new_arc = new Flatten.Arc(this.pc, this.r, this.startAngle, this.endAngle, this.counterClockwise);
-            }
-            // It could be 2*PI when occasionally start = 0 and end = 2*PI but this is not valid for breakToFunctional
-            if (!Flatten.Utils.EQ_0(new_arc.length) && !Flatten.Utils.EQ(new_arc.sweep, 2*Math.PI)) {
-                func_arcs_array.push(new_arc.clone());
-            }
+        // set up the loop
+        let prev = startAngle;
+        let next;
+        let firstj;
+        let d;
+        if (this.counterClockwise) {
+            firstj = Math.ceil(startAngle / (Math.PI / 2)) % 4;
+            d = 1;
+        } else {
+            firstj = Math.floor(startAngle / (Math.PI / 2)) % 4;
+            d = -1;
         }
+
+        // loop over crossings while incremental sweep is less than sweep
+        for (let i = 0, j = firstj; i < 4; i++, j = (j + d + 4) % 4) {
+            next = angles[j];
+            if (next === prev) {
+                continue;
+            }
+            let incrementalSweep = this.counterClockwise ? next - startAngle : startAngle - next;
+            if (incrementalSweep < 0) {
+                incrementalSweep += Flatten.PIx2;
+            }
+            if (incrementalSweep > sweep) {
+                break;
+            }
+            func_arcs_array.push(new Flatten.Arc(this.pc, this.r, prev, next, this.counterClockwise));
+            prev = next;
+        }
+
+        // return the original arc for no crossings
+        if (func_arcs_array.length === 0) {
+            func_arcs_array.push(this);
+            return func_arcs_array;
+        }
+
+        // add the last arc
+        next = endAngle;
+        if (prev !== next) {
+            func_arcs_array.push(new Flatten.Arc(this.pc, this.r, prev, next, this.counterClockwise));
+        }
+
         return func_arcs_array;
     }
 

--- a/src/classes/arc.js
+++ b/src/classes/arc.js
@@ -83,30 +83,6 @@ export class Arc extends Shape {
      * Get sweep angle in radians. Sweep angle is non-negative number from 0 to 2*PI
      * @returns {number}
      */
-    // get sweep() {
-    //     if (Flatten.Utils.EQ(this.startAngle, this.endAngle))
-    //         return 0.0;
-    //     if (Flatten.Utils.EQ(Math.abs(this.startAngle - this.endAngle), Flatten.PIx2)) {
-    //         return Flatten.PIx2;
-    //     }
-    //     let sweep;
-    //     if (this.counterClockwise) {
-    //         sweep = Flatten.Utils.GT(this.endAngle, this.startAngle) ?
-    //             this.endAngle - this.startAngle : this.endAngle - this.startAngle + Flatten.PIx2;
-    //     } else {
-    //         sweep = Flatten.Utils.GT(this.startAngle, this.endAngle) ?
-    //             this.startAngle - this.endAngle : this.startAngle - this.endAngle + Flatten.PIx2;
-    //     }
-    //
-    //     if (Flatten.Utils.GT(sweep, Flatten.PIx2)) {
-    //         sweep -= Flatten.PIx2;
-    //     }
-    //     if (Flatten.Utils.LT(sweep, 0)) {
-    //         sweep += Flatten.PIx2;
-    //     }
-    //     return sweep;
-    // }
-
     get sweep() {
         let startAngle = this.startAngle;
         let endAngle = this.endAngle;
@@ -446,7 +422,7 @@ export class Arc extends Shape {
     }
 
     /**
-     * Returns new arc with swapped start and end angles and reversed direction
+     * Returns new arc with swapped start and end angles asweepnd reversed direction
      * @returns {Arc}
      */
     reverse() {

--- a/src/classes/arc.js
+++ b/src/classes/arc.js
@@ -47,7 +47,7 @@ export class Arc extends Shape {
          * Arc orientation
          * @type {boolean}
          */
-        this.counterClockwise = Flatten.CCW;
+        this.counterClockwise = true;
 
         if (args.length === 0)
             return;
@@ -83,28 +83,63 @@ export class Arc extends Shape {
      * Get sweep angle in radians. Sweep angle is non-negative number from 0 to 2*PI
      * @returns {number}
      */
+    // get sweep() {
+    //     if (Flatten.Utils.EQ(this.startAngle, this.endAngle))
+    //         return 0.0;
+    //     if (Flatten.Utils.EQ(Math.abs(this.startAngle - this.endAngle), Flatten.PIx2)) {
+    //         return Flatten.PIx2;
+    //     }
+    //     let sweep;
+    //     if (this.counterClockwise) {
+    //         sweep = Flatten.Utils.GT(this.endAngle, this.startAngle) ?
+    //             this.endAngle - this.startAngle : this.endAngle - this.startAngle + Flatten.PIx2;
+    //     } else {
+    //         sweep = Flatten.Utils.GT(this.startAngle, this.endAngle) ?
+    //             this.startAngle - this.endAngle : this.startAngle - this.endAngle + Flatten.PIx2;
+    //     }
+    //
+    //     if (Flatten.Utils.GT(sweep, Flatten.PIx2)) {
+    //         sweep -= Flatten.PIx2;
+    //     }
+    //     if (Flatten.Utils.LT(sweep, 0)) {
+    //         sweep += Flatten.PIx2;
+    //     }
+    //     return sweep;
+    // }
+
     get sweep() {
-        if (Flatten.Utils.EQ(this.startAngle, this.endAngle))
-            return 0.0;
-        if (Flatten.Utils.EQ(Math.abs(this.startAngle - this.endAngle), Flatten.PIx2)) {
-            return Flatten.PIx2;
-        }
+        let startAngle = this.startAngle;
+        let endAngle = this.endAngle;
         let sweep;
-        if (this.counterClockwise) {
-            sweep = Flatten.Utils.GT(this.endAngle, this.startAngle) ?
-                this.endAngle - this.startAngle : this.endAngle - this.startAngle + Flatten.PIx2;
-        } else {
-            sweep = Flatten.Utils.GT(this.startAngle, this.endAngle) ?
-                this.startAngle - this.endAngle : this.startAngle - this.endAngle + Flatten.PIx2;
+
+        // check full circle before normalizing angles
+        if (Flatten.Utils.EQ(Math.abs(startAngle - endAngle), Flatten.PIx2)) {
+            sweep = Flatten.PIx2;
+            endAngle = startAngle;
         }
 
-        if (Flatten.Utils.GT(sweep, Flatten.PIx2)) {
-            sweep -= Flatten.PIx2;
+        // normalize angles
+        if (Math.abs(startAngle) > Flatten.PIx2) {
+            startAngle -= Math.trunc(startAngle / Flatten.PIx2) * Flatten.PIx2;
         }
-        if (Flatten.Utils.LT(sweep, 0)) {
-            sweep += Flatten.PIx2;
+        if (startAngle < 0) {
+            startAngle += Flatten.PIx2;
         }
-        return sweep;
+        if (Math.abs(endAngle) > Flatten.PIx2) {
+            endAngle -= Math.trunc(endAngle / Flatten.PIx2) * Flatten.PIx2;
+        }
+        if (endAngle < 0) {
+            endAngle += Flatten.PIx2;
+        }
+
+        // calculate sweep if it isn't a full circle
+        if (sweep === undefined) {
+            sweep = this.counterClockwise ? endAngle - startAngle : startAngle - endAngle;
+            if (sweep < 0) {
+                sweep += Flatten.PIx2;
+            }
+        }
+        return sweep
     }
 
     /**
@@ -325,11 +360,9 @@ export class Arc extends Shape {
         let angles = [0, Math.PI / 2, Math.PI, 3 * Math.PI / 2];
         let startAngle = this.startAngle;
         let endAngle = this.endAngle;
-        let sweep;
 
         // check full circle before normalizing angles
         if (Flatten.Utils.EQ(Math.abs(startAngle - endAngle), Flatten.PIx2)) {
-            sweep = Flatten.PIx2;
             endAngle = startAngle;
         }
 
@@ -345,14 +378,6 @@ export class Arc extends Shape {
         }
         if (endAngle < 0) {
             endAngle += Flatten.PIx2;
-        }
-
-        // calculate sweep if it isn't a full circle
-        if (sweep === undefined) {
-            sweep = this.counterClockwise ? endAngle - startAngle : startAngle - endAngle;
-            if (sweep < 0) {
-                sweep += Flatten.PIx2;
-            }
         }
 
         // set up the loop
@@ -378,7 +403,7 @@ export class Arc extends Shape {
             if (incrementalSweep < 0) {
                 incrementalSweep += Flatten.PIx2;
             }
-            if (incrementalSweep > sweep) {
+            if (incrementalSweep > this.sweep) {
                 break;
             }
             func_arcs_array.push(new Flatten.Arc(this.pc, this.r, prev, next, this.counterClockwise));
@@ -466,14 +491,10 @@ export class Arc extends Shape {
     circularSegmentDefiniteIntegral(ymin) {
         let segment = new Flatten.Segment(this.start, this.end);
         let areaTrapez = segment.definiteIntegral(ymin);
-        let areaCircularSegment = this.circularSegmentArea();
-        if (this.start.equalTo(this.end) && Flatten.Utils.EQ_0(areaCircularSegment)) {
-            return areaTrapez
-        } else {
-            let line = new Flatten.Line(this.start, this.end);
-            let onLeftSide = this.pc.leftTo(line);
-            return onLeftSide ? areaTrapez - areaCircularSegment : areaTrapez + areaCircularSegment;
-        }
+        // can't be full circle after breakToFunctional, consider zero-arc
+        let areaCircularSegment = Flatten.Utils.EQ(this.sweep, Flatten.PIx2)
+            ? 0 : this.circularSegmentArea();
+        return this.counterClockwise ? areaTrapez - areaCircularSegment : areaTrapez + areaCircularSegment;
     }
 
     circularSegmentArea() {

--- a/src/classes/arc.js
+++ b/src/classes/arc.js
@@ -86,12 +86,10 @@ export class Arc extends Shape {
     get sweep() {
         let startAngle = this.startAngle;
         let endAngle = this.endAngle;
-        let sweep;
 
-        // check full circle before normalizing angles
+        // check full circle
         if (Flatten.Utils.EQ(Math.abs(startAngle - endAngle), Flatten.PIx2)) {
-            sweep = Flatten.PIx2;
-            endAngle = startAngle;
+            return Flatten.PIx2;
         }
 
         // normalize angles
@@ -108,12 +106,10 @@ export class Arc extends Shape {
             endAngle += Flatten.PIx2;
         }
 
-        // calculate sweep if it isn't a full circle
-        if (sweep === undefined) {
-            sweep = this.counterClockwise ? endAngle - startAngle : startAngle - endAngle;
-            if (sweep < 0) {
-                sweep += Flatten.PIx2;
-            }
+        // calculate sweep
+        let sweep = this.counterClockwise ? endAngle - startAngle : startAngle - endAngle;
+        if (sweep < 0) {
+            sweep += Flatten.PIx2;
         }
         return sweep
     }

--- a/test/classes/arc.js
+++ b/test/classes/arc.js
@@ -137,7 +137,7 @@ describe('#Flatten.Arc', function() {
             expect(Flatten.Utils.EQ(f_arcs[0].startAngle, arc.startAngle)).to.equal(true);
             expect(Flatten.Utils.EQ(f_arcs[0].endAngle, 0)).to.equal(true);
             expect(Flatten.Utils.EQ(f_arcs[1].startAngle, 0)).to.equal(true);
-            expect(Flatten.Utils.EQ(f_arcs[1].endAngle, arc.endAngle)).to.equal(true);
+            expect(Flatten.Utils.EQ(f_arcs[1].endAngle, 2 * Math.PI + arc.endAngle)).to.equal(true);
         });
         it('Case 4. One intersection, start at extreme point', function () {
             let arc = new Arc(new Point(), 1, Math.PI/2, 3*Math.PI/4, true);
@@ -164,7 +164,7 @@ describe('#Flatten.Arc', function() {
             expect(Flatten.Utils.EQ(f_arcs[1].startAngle, Math.PI/2)).to.equal(true);
             expect(Flatten.Utils.EQ(f_arcs[1].endAngle, 0)).to.equal(true);
             expect(Flatten.Utils.EQ(f_arcs[2].startAngle, 0)).to.equal(true);
-            expect(Flatten.Utils.EQ(f_arcs[2].endAngle, arc.endAngle)).to.equal(true);
+            expect(Flatten.Utils.EQ(f_arcs[2].endAngle, 2 * Math.PI + arc.endAngle)).to.equal(true);
         });
         it('Case 7. 2 intersections on extreme points, 1 parts, CW', function () {
             let arc = new Arc(new Point(), 1, Math.PI/2, 0, false);

--- a/test/classes/arc.js
+++ b/test/classes/arc.js
@@ -185,6 +185,21 @@ describe('#Flatten.Arc', function() {
             let f_arcs = arc.breakToFunctional();
             expect(f_arcs.length).to.equal(4);
         });
+        it('#220 case 1. Start/end very close to extreme points', function () {
+            let arc = new Arc (new Point(0, 0), 1, 2 * Math.PI * 0.9999999, 0.000001, true)
+            let f_arcs = arc.breakToFunctional();
+            expect(f_arcs.length).to.equal(2);
+        })
+        it('#220 case 2. Start/end very close to extreme points', function () {
+            let arc = new Arc(new Point(0, 0), 1, 2 * Math.PI * 0.9999999, (Math.PI / 2) * 0.9999993, true)
+            let f_arcs = arc.breakToFunctional();
+            expect(f_arcs.length).to.equal(2);
+        })
+        it('#220 case 3. Start/end very close to extreme points', function () {
+            let arc = new Arc(new Point(), 1, 2 * Math.PI * 1.4999998, 0.000001, true)
+            let f_arcs = arc.breakToFunctional();
+            expect(f_arcs.length).to.equal(4);
+        })
     });
     describe('#Flatten.Arc.intersect', function() {
         it('Intersect arc with segment', function() {

--- a/test/classes/face.js
+++ b/test/classes/face.js
@@ -187,4 +187,30 @@ describe('#Flatten.Face', function() {
         }
 
     });
+    it('Can calculate signed area of ccw polygon with cw arc', function () {
+        const shapes = [
+            new Segment(new Point(0, 0), new Point(2, 0)),
+            new Segment(new Point(2, 0), new Point(2, 1)),
+            new Arc(new Point(3, 1), 1, Math.PI, Math.PI/2, false),
+            new Segment(new Point(3, 2), new Point(0, 2)),
+            new Segment(new Point(0, 2), new Point(0, 0))
+        ]
+        const polygon = new Polygon();
+        const face = polygon.addFace(shapes);
+        expect(face.signedArea()).to.approximately(-(4 + (1 - Math.PI/4)), Flatten.DP_TOL);
+        expect(face.orientation()).to.equal(Flatten.ORIENTATION.CCW);
+    })
+    it('Can calculate signed area of cw polygon with ccw arc', function () {
+        const shapes = [
+            new Segment(new Point(0, 0), new Point(0, 2)),
+            new Segment(new Point(0, 2), new Point(3, 2)),
+            new Arc(new Point(3, 1), 1, Math.PI/2, Math.PI, true),
+            new Segment(new Point(2, 1), new Point(2, 0)),
+            new Segment(new Point(2, 0), new Point(0, 0))
+        ]
+        const polygon = new Polygon();
+        const face = polygon.addFace(shapes);
+        expect(face.signedArea()).to.approximately(4 + (1 - Math.PI/4), Flatten.DP_TOL);
+        expect(face.orientation()).to.equal(Flatten.ORIENTATION.CW);
+    })
 });

--- a/test/classes/polygon.js
+++ b/test/classes/polygon.js
@@ -322,15 +322,22 @@ describe('#Flatten.Polygon', function() {
         expect(polygon.area()).to.equal(2);
     });
     it('"Illegal parameters" when computing area of a valid polygon #220', function () {
+        // This test (and the code of arc.breakToFunctional and arc.sweep)
+        // assumes that arcs become circles only when abs(startAngle - endAngle)
+        // is 2 PI within tolerance, but not when the span of the angles we pass
+        // in is *bigger* than 2 PI. That's as good a choice as any, and seems
+        // to be consistent behavior across Flatten, but it's worth noting that
+        // it could be that anything > 2 PI is a circle, and this would allow
+        // for arcs arbitrarily close to full circles (within float epsilon) to
+        // be distinguished from circles and treated appropriately.
         const c3 = new Polygon([
             arc(point(0, 0), 1, 2 * Math.PI * 1.4999998, 0.000001, true),
-            segment(point(1, 0), point(Math.SQRT1_2, Math.SQRT1_2)),
-            segment(point(Math.SQRT1_2, Math.SQRT1_2), point(-1, 0))
+            segment(point(1, 0).rotate(0.000001), point(0, 0)),
+            segment(point(0, 0), point(1, 0).rotate(2 * Math.PI * 1.4999998)),
         ]);
 
         const area = c3.area();
-        // expect to be almost equal to 2.2779 with tolerance 0.001
-        expect(area).to.be.approximately(2.2779, 0.001);
+        expect(area).to.be.approximately(((2 * Math.PI * 1.4999998 - 2 * Math.PI) + 0.000001) / 2, 0.001);
     })
     it('Can check point in contour. Donut Case 1 Boundary top',function() {
         let polygon = new Polygon();

--- a/test/classes/polygon.js
+++ b/test/classes/polygon.js
@@ -321,7 +321,7 @@ describe('#Flatten.Polygon', function() {
         ]);
         expect(polygon.area()).to.equal(2);
     });
-    it('"Illegal parameters" when computing area of a valid polygon #220', function () {
+    it('"Illegal parameters" when computing area of a valid polygon #220 case 3', function () {
         // This test (and the code of arc.breakToFunctional and arc.sweep)
         // assumes that arcs become circles only when abs(startAngle - endAngle)
         // is 2 PI within tolerance, but not when the span of the angles we pass
@@ -338,6 +338,27 @@ describe('#Flatten.Polygon', function() {
 
         const area = c3.area();
         expect(area).to.be.approximately(((2 * Math.PI * 1.4999998 - 2 * Math.PI) + 0.000001) / 2, 0.001);
+    })
+    it('"Illegal parameters" when computing area of a valid polygon #220 case #1', function () {
+        const a1 = arc(point(0, 0), 1, 2 * Math.PI * 0.9999999, 0.000001, true);
+        const c1 = new Polygon([
+            a1,
+            segment(a1.end, point(Math.SQRT1_2, Math.SQRT1_2)),
+            segment(point(Math.SQRT1_2, Math.SQRT1_2), a1.start)
+        ]);
+        const area1 = c1.area();
+        expect(area1).to.be.lessThan(Flatten.DP_TOL);
+    })
+    it('"Illegal parameters" when computing area of a valid polygon #220 case #2', function () {
+        const a2 = arc(point(0, 0), 1, 2 * Math.PI * 0.9999999, (Math.PI / 2) * 0.9999993, true)
+        const c2 = new Polygon([
+            a2,
+            segment(a2.end, point(Math.SQRT1_2, Math.SQRT1_2)),
+            segment(point(Math.SQRT1_2, Math.SQRT1_2), a2.start)
+        ]);
+
+        const area2 = c2.area();
+        expect(area2).to.be.approximately(Math.PI/4 - Math.SQRT1_2, 0.001);
     })
     it('Can check point in contour. Donut Case 1 Boundary top',function() {
         let polygon = new Polygon();


### PR DESCRIPTION
…comparisons

This fixes some issues where breakToFunctional would occasionally create small angles that were not actually part of the original arc, as well as angles > 2 PI. Accuracy should be slightly improved. Speed difference should be favorable, if small. Vaguely related to #220.

The test is changed since the original test was not, actually, a valid polygon. I did verify that this new polygon will produce an error with earlier versions.