### PR TITLE
feat(types): add box helper to types and fix circle center property name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -117,7 +117,7 @@ declare namespace Flatten {
         counterClockwise: boolean;
 
         // members
-        ps: Point;
+        pc: Point;
         r: number;
         startAngle: number;
         endAngle: number;
@@ -632,6 +632,7 @@ declare namespace Flatten {
 
     function point(x?: number, y?: number): Point;
     function point(arr?: [number, number]): Point;
+    function box(xmin: number, ymin: number, xmax: number, ymax: number) : Box
     function circle(pc: Point, r: number) : Circle;
     function line(pt?: Point, norm?: Vector) : Line;
     function line(norm?: Vector, pt?: Point) : Line;


### PR DESCRIPTION
box helper was missing in types
and fix #245