### PR TITLE
Fix Box.distanceTo(Box) crash by adding missing Box branch to Segment.distanceTo (#210)

### DIFF
--- a/src/classes/segment.js
+++ b/src/classes/segment.js
@@ -228,6 +228,11 @@ export class Segment extends Shape {
             return [dist, shortest_segment];
         }
 
+        if (shape instanceof Flatten.Box) {
+            let [dist, shortest_segment] = Flatten.Distance.shape2polygon(this, new Flatten.Polygon(shape));
+            return [dist, shortest_segment];
+        }
+
         if (shape instanceof Flatten.Polygon) {
             let [dist, shortest_segment] = Flatten.Distance.shape2polygon(this, shape);
             return [dist, shortest_segment];

--- a/test/classes/repro_issue_210.js
+++ b/test/classes/repro_issue_210.js
@@ -1,0 +1,32 @@
+'use strict';
+
+import { expect } from 'chai';
+import Flatten from '../../index';
+import { Box, Segment, Point } from '../../index';
+
+// Regression test for issue #210
+// Box.distanceTo(shape) maps each of the box's 4 edges to Segment.distanceTo(shape),
+// but Segment.distanceTo had no Box branch, so passing a Box returned undefined and
+// Box.distanceTo(Box) crashed with "Cannot read properties of undefined (reading '0')".
+describe('#Flatten.Box.distanceTo(Box) (issue #210)', function () {
+    it('does not throw and returns 0 for overlapping boxes (reporter coordinates)', function () {
+        const a = new Box(11.997102737426758, 6.649463176727295, 13.695880889892578, 7.980637073516846);
+        const b = new Box(13.374691009521484, 6.007083415985107, 15.073468208312988, 7.338257312774658);
+        const [dist] = a.distanceTo(b);
+        expect(dist).to.equal(0);
+    });
+    it('returns the boundary gap for disjoint boxes', function () {
+        const a = new Box(0, 0, 1, 1);
+        const b = new Box(3, 0, 4, 1);
+        const [dist] = a.distanceTo(b);
+        expect(dist).to.equal(2);
+    });
+    it('Segment.distanceTo(Box) returns the boundary gap and shortest segment', function () {
+        const segment = new Segment(new Point(-2, 0.5), new Point(-1, 0.5));
+        const box = new Box(0, 0, 1, 1);
+        const [dist, shortest_segment] = segment.distanceTo(box);
+        expect(dist).to.equal(1);
+        expect(shortest_segment.ps).to.deep.include({ x: -1, y: 0.5 });
+        expect(shortest_segment.pe).to.deep.include({ x: 0, y: 0.5 });
+    });
+});


### PR DESCRIPTION
Fixes #210.

## Root cause
`Box.distanceTo(shape)` maps the box's four edges to `segment.distanceTo(shape)` and then reads `distanceInfo[0]` for each result. `Segment.distanceTo` has no `Box` case, so when the argument is a `Box` it falls through every branch and returns `undefined`. `Box.distanceTo` then crashes with `TypeError: Cannot read properties of undefined (reading '0')`, which means `Box.distanceTo(Box)` throws every time (reported by @henhal, who diagnosed the exact root cause).

## Fix
Add the missing `Box` branch to `Segment.distanceTo`. It converts the box to a polygon (the `Polygon` constructor already accepts a `Box`) and reuses the existing `Distance.shape2polygon`, mirroring the adjacent `Polygon` branch and its `[dist, shortest_segment]` return convention. This gives boundary-to-boundary distance consistent with the rest of the library: overlapping boxes -> 0, disjoint boxes -> the boundary gap.

## Tests
Added `test/classes/repro_issue_210.js`:
- Box <-> Box overlapping (reporter's exact coordinates) -> 0 (previously threw)
- Box <-> Box disjoint -> correct boundary gap
- Segment -> Box -> correct gap and shortest segment

Verified red -> green (the three tests fail with the reported `TypeError` before the fix, pass after) and the full suite stays green (536 passing).

## Credit
Thanks to @henhal for the report and the precise root-cause analysis.

---
This contribution was prepared with AI assistance and reviewed by me before submission.